### PR TITLE
feat(alt-codes): add emoji aliases and tags from gemoji

### DIFF
--- a/apps/alt-codes/package.json
+++ b/apps/alt-codes/package.json
@@ -28,6 +28,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "tailwindcss": "^4.1.12",
+    "gemoji": "^8.1.0",
     "unicode-emoji-json": "^0.8.0",
     "vike": "0.4.239-commit-9dcde6d",
     "vike-react": "^0.6.5"

--- a/apps/alt-codes/pages/+Page.tsx
+++ b/apps/alt-codes/pages/+Page.tsx
@@ -19,6 +19,7 @@ function matchesSearch(c: GridEntry, q: string): boolean {
     c.hex.toLowerCase().includes(q) ||
     c.name.toLowerCase().includes(q) ||
     c.aliases.some((a) => a.toLowerCase().includes(q)) ||
+    c.tags.some((t) => t.toLowerCase().includes(q)) ||
     (c.altCode !== null && c.altCode.toString().includes(q))
   );
 }

--- a/apps/alt-codes/pages/symbol/@hexOrSlugifiedName/+Page.tsx
+++ b/apps/alt-codes/pages/symbol/@hexOrSlugifiedName/+Page.tsx
@@ -144,7 +144,7 @@ function SkinTonePicker({
 }
 
 export default function Page() {
-  const { entry, categoryName, encoding, blockNeighbors, relatedByName } = useData<SymbolData>();
+  const { entry, categoryName, encoding, blockNeighbors, relatedByName, relatedByTag } = useData<SymbolData>();
   const [displayChar, setDisplayChar] = useState(entry.char);
 
   // Reset variant when navigating to a new symbol
@@ -191,6 +191,13 @@ export default function Page() {
                 <ul className="symbol-alias-list" aria-label="Also known as">
                   {entry.aliases.map(a => (
                     <li key={a} className="symbol-alias-tag">{a}</li>
+                  ))}
+                </ul>
+              )}
+              {entry.tags.length > 0 && (
+                <ul className="symbol-tag-list" aria-label="Tags">
+                  {entry.tags.map(t => (
+                    <li key={t} className="symbol-tag">{t}</li>
                   ))}
                 </ul>
               )}
@@ -258,6 +265,16 @@ export default function Page() {
               <h2 className="symbol-section-title">Related characters</h2>
               <div className="mini-grid">
                 {relatedByName.map((c) => <MiniCard key={codePointsKey(c.codePoints)} entry={c} />)}
+              </div>
+            </section>
+          )}
+
+          {/* Related by tag */}
+          {relatedByTag.length > 0 && (
+            <section className="symbol-section">
+              <h2 className="symbol-section-title">Related by tag</h2>
+              <div className="mini-grid">
+                {relatedByTag.map((c) => <MiniCard key={codePointsKey(c.codePoints)} entry={c} />)}
               </div>
             </section>
           )}

--- a/apps/alt-codes/pages/symbol/@hexOrSlugifiedName/+data.server.ts
+++ b/apps/alt-codes/pages/symbol/@hexOrSlugifiedName/+data.server.ts
@@ -9,6 +9,7 @@ export type SymbolData = {
   encoding: EncodingInfo;
   blockNeighbors: CharacterEntry[];
   relatedByName: CharacterEntry[];
+  relatedByTag: CharacterEntry[];
 };
 
 // Words too common in Unicode names to be useful signals
@@ -72,5 +73,24 @@ export async function data(pageContext: PageContextServer): Promise<SymbolData> 
     relatedByName.push(...scored.slice(0, 16).map(s => s.entry));
   }
 
-  return { entry, categoryName, encoding, blockNeighbors, relatedByName };
+  // Related by tag: emoji sharing at least one gemoji tag
+  const relatedByTag: CharacterEntry[] = [];
+  if (entry.tags.length > 0) {
+    const entryTags = new Set(entry.tags);
+    const seen = new Set<string>([key, ...relatedByName.map(c => codePointsKey(c.codePoints))]);
+    const scored: Array<{ entry: CharacterEntry; shared: number }> = [];
+    for (const c of characters) {
+      const cKey = codePointsKey(c.codePoints);
+      if (seen.has(cKey) || c.tags.length === 0) continue;
+      const shared = c.tags.filter(t => entryTags.has(t)).length;
+      if (shared > 0) {
+        seen.add(cKey);
+        scored.push({ entry: c, shared });
+      }
+    }
+    scored.sort((a, b) => b.shared - a.shared);
+    relatedByTag.push(...scored.slice(0, 16).map(s => s.entry));
+  }
+
+  return { entry, categoryName, encoding, blockNeighbors, relatedByName, relatedByTag };
 }

--- a/apps/alt-codes/pages/unicode-loader.server.ts
+++ b/apps/alt-codes/pages/unicode-loader.server.ts
@@ -10,6 +10,9 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 const dataOrderedEmoji = require('unicode-emoji-json/data-ordered-emoji.json') as string[];
 const dataByEmoji = require('unicode-emoji-json/data-by-emoji.json') as Record<string, EmojiJsonEntry>;
+const gemojiData = require('gemoji') as {
+  gemoji: Array<{ emoji: string; names: string[]; tags: string[] }>;
+};
 
 import { CP437_SPECIAL, codePointsKey, type CharacterEntry, type UnicodeData } from '../src/unicode-data';
 
@@ -98,6 +101,12 @@ function buildEmojiCharacters(): CharacterEntry[] {
   const ordered = dataOrderedEmoji as string[];
   const entries: CharacterEntry[] = [];
 
+  // Build lookup from emoji character → gemoji entry for aliases + tags
+  const gemojiByEmoji = new Map<string, { names: string[]; tags: string[] }>();
+  for (const g of gemojiData.gemoji) {
+    gemojiByEmoji.set(g.emoji, g);
+  }
+
   for (const emojiChar of ordered) {
     const meta = byEmoji[emojiChar];
     if (!meta) continue;
@@ -108,6 +117,10 @@ function buildEmojiCharacters(): CharacterEntry[] {
     const codePoints = [...emojiChar].map((c) => c.codePointAt(0)!);
     const firstCp = codePoints[0];
 
+    const gEntry = gemojiByEmoji.get(emojiChar);
+    const aliases = gEntry ? gEntry.names.map(n => `:${n}:`) : [];
+    const tags = gEntry?.tags ?? [];
+
     entries.push({
       codePoints,
       char: emojiChar,
@@ -116,7 +129,8 @@ function buildEmojiCharacters(): CharacterEntry[] {
       categoryId,
       altCode: null,
       name: meta.name.toUpperCase(),
-      aliases: [],
+      aliases,
+      tags,
       emoji: {
         group: meta.group,
         subgroup: meta.slug.replace(/_/g, '-'),
@@ -140,6 +154,7 @@ function makeEntry(codePoint: number, categoryId: string): CharacterEntry {
     altCode: unicodeToAlt.get(codePoint) ?? null,
     name: unicodeNames.get(codePoint) ?? '',
     aliases: getAliases(codePoint),
+    tags: [],
     emoji: null,
   };
 }

--- a/apps/alt-codes/src/style.css
+++ b/apps/alt-codes/src/style.css
@@ -512,6 +512,26 @@ body {
   line-height: 1.5;
 }
 
+.symbol-tag-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.symbol-tag {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--color-muted);
+  background: color-mix(in srgb, var(--color-border) 40%, transparent);
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  padding: 2px 7px;
+  line-height: 1.5;
+}
+
 /* ── Sections ─────────────────────────────────── */
 
 .symbol-section {

--- a/apps/alt-codes/src/unicode-data.ts
+++ b/apps/alt-codes/src/unicode-data.ts
@@ -15,6 +15,7 @@ export interface CharacterEntry {
   altCode: number | null;
   name: string;
   aliases: string[];
+  tags: string[];
   emoji: EmojiMeta | null;    // null for non-emoji
 }
 
@@ -28,6 +29,7 @@ export interface GridEntry {
   categoryId: string;
   altCode: number | null;
   aliases: string[];
+  tags: string[];
 }
 
 export function toGridEntry(entry: CharacterEntry): GridEntry {
@@ -39,6 +41,7 @@ export function toGridEntry(entry: CharacterEntry): GridEntry {
     categoryId: entry.categoryId,
     altCode: entry.altCode,
     aliases: entry.aliases,
+    tags: entry.tags,
   };
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,7 +102,7 @@ importers:
         version: 2.8.1
       vike:
         specifier: 0.4.239-commit-9dcde6d
-        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       vike-react:
         specifier: ^0.5.4
         version: 0.5.13(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)))
@@ -175,7 +175,7 @@ importers:
         version: 7.16.1(eslint@8.57.0)(typescript@5.9.2)
       '@vitejs/plugin-react':
         specifier: 5.0.2
-        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       '@vitest/coverage-v8':
         specifier: 4.0.9
         version: 4.0.9(vitest@4.0.9)
@@ -298,7 +298,10 @@ importers:
         version: 1.6.16
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+      gemoji:
+        specifier: ^8.1.0
+        version: 8.1.0
       react:
         specifier: ^19.1.1
         version: 19.1.1
@@ -313,7 +316,7 @@ importers:
         version: 0.8.0
       vike:
         specifier: 0.4.239-commit-9dcde6d
-        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       vike-react:
         specifier: ^0.6.5
         version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)))
@@ -336,7 +339,7 @@ importers:
         version: 19.1.9(@types/react@19.1.12)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       graphiql:
         specifier: ^3.8.3
         version: 3.9.0(@codemirror/language@6.0.0)(@types/node@22.18.1)(@types/react-dom@19.1.9(@types/react@19.1.12))(@types/react@19.1.12)(graphql@16.13.2)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
@@ -351,7 +354,7 @@ importers:
         version: 4.1.12
       vike:
         specifier: 0.4.239-commit-9dcde6d
-        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       vike-react:
         specifier: ^0.6.5
         version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)))
@@ -369,7 +372,7 @@ importers:
         version: 19.1.9(@types/react@19.1.12)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       ace-code:
         specifier: ^1.43.6
         version: 1.43.6
@@ -399,7 +402,7 @@ importers:
         version: 5.9.2
       vike:
         specifier: 0.4.239-commit-9dcde6d
-        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       vike-react:
         specifier: ^0.6.5
         version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)))
@@ -420,7 +423,7 @@ importers:
         version: 19.1.9(@types/react@19.1.12)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -441,7 +444,7 @@ importers:
         version: 5.9.2
       vike:
         specifier: 0.4.239-commit-9dcde6d
-        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       vike-react:
         specifier: ^0.6.5
         version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)))
@@ -477,7 +480,7 @@ importers:
         version: 4.1.12
       vike:
         specifier: 0.4.239-commit-9dcde6d
-        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       vike-react:
         specifier: ^0.6.5
         version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)))
@@ -522,7 +525,7 @@ importers:
         version: 4.1.12
       vike:
         specifier: 0.4.239-commit-9dcde6d
-        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       vike-react:
         specifier: ^0.6.5
         version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)))
@@ -540,7 +543,7 @@ importers:
         version: 19.1.9(@types/react@19.1.12)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
@@ -561,7 +564,7 @@ importers:
         version: 4.1.12
       vike:
         specifier: 0.4.239-commit-9dcde6d
-        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+        version: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
       vike-react:
         specifier: ^0.6.5
         version: 0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)))
@@ -6761,6 +6764,9 @@ packages:
   gcp-metadata@7.0.1:
     resolution: {integrity: sha512-UcO3kefx6dCcZkgcTGgVOTFb7b1LlQ02hY1omMjjrrBzkajRMCFgYOjs7J71WqnuG1k2b+9ppGL7FsOfhZMQKQ==}
     engines: {node: '>=18'}
+
+  gemoji@8.1.0:
+    resolution: {integrity: sha512-HA4Gx59dw2+tn+UAa7XEV4ufUKI4fH1KgcbenVA9YKSj1QJTT0xh5Mwv5HMFNN3l2OtUe3ZIfuRwSyZS5pLIWw==}
 
   generic-names@4.0.0:
     resolution: {integrity: sha512-ySFolZQfw9FoDb3ed9d80Cm9f0+r7qj+HJkWjeD9RBfpxEVTlVhol+gvaQB/78WbwYfbnNh8nWHHBSlg072y6A==}
@@ -15848,7 +15854,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@vitejs/plugin-react@5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))':
+  '@vitejs/plugin-react@5.0.2(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.3)
@@ -15886,7 +15892,7 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.0.3
 
-  '@vitest/mocker@4.0.9(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))':
+  '@vitest/mocker@4.0.9(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))':
     dependencies:
       '@vitest/spy': 4.0.9
       estree-walker: 3.0.3
@@ -18641,6 +18647,8 @@ snapshots:
       json-bigint: 1.0.0
     transitivePeerDependencies:
       - supports-color
+
+  gemoji@8.1.0: {}
 
   generic-names@4.0.0:
     dependencies:
@@ -23730,16 +23738,16 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       react-streaming: 0.3.50(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      vike: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+      vike: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
 
   vike-react@0.6.5(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))):
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
       react-streaming: 0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      vike: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
+      vike: 0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
 
-  vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)):
+  vike@0.4.239-commit-9dcde6d(patch_hash=glgnedzwnw5rvkijrtehacjmkm)(react-streaming@0.4.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1))(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1)):
     dependencies:
       '@brillout/import': 0.2.6
       '@brillout/json-serializer': 0.5.20
@@ -23827,7 +23835,7 @@ snapshots:
   vitest@4.0.9(@types/debug@4.1.12)(@types/node@22.18.1)(@vitest/ui@4.0.9)(jiti@2.5.1)(jsdom@22.1.0)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1):
     dependencies:
       '@vitest/expect': 4.0.9
-      '@vitest/mocker': 4.0.9(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.1))
+      '@vitest/mocker': 4.0.9(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))
       '@vitest/pretty-format': 4.0.9
       '@vitest/runner': 4.0.9
       '@vitest/snapshot': 4.0.9


### PR DESCRIPTION
Use the gemoji package to populate emoji shortcode aliases (e.g. :tada:
for party popper) and descriptive tags (e.g. hooray, party). Aliases
appear in the "Also known as" section, tags are displayed separately
with distinct styling. Tags are searchable on the home page and emoji
sharing tags are surfaced as "Related by tag" on detail pages.

https://claude.ai/code/session_01SKfHtg52v5wMTBUi7K2o9H