### PR TITLE
fix(craigory-dev): include base URL in local project deployment URLs

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,7 +65,7 @@ jobs:
           # avoiding stdout maxBuffer overflow in the deploy executor.
           real_git=$(which git)
           mkdir -p /tmp/quiet-git
-          printf '#!/bin/bash\ncase "$1" in\n  commit|fetch|push|init) exec "%s" "$1" --quiet "${@:2}" ;;\n  *) exec "%s" "$@" ;;\nesac\n' "$real_git" "$real_git" > /tmp/quiet-git/git
+          printf '#!/bin/bash\nexec "%s" "$@" > /dev/null 2>&1\n' "$real_git" > /tmp/quiet-git/git
           chmod +x /tmp/quiet-git/git
           export PATH="/tmp/quiet-git:$PATH"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -60,6 +60,15 @@ jobs:
           mkdir -p ./dist/gh-pages-root/pr/$GITHUB_SHA
           cp -r ./dist/apps/craigory-dev/client "./dist/gh-pages-root${PATH_PREFIX}"
           cp ./dist/apps/craigory-dev/client/CNAME ./dist/gh-pages-root
+
+          # Wrap git to add --quiet to commands that produce excessive output,
+          # avoiding stdout maxBuffer overflow in the deploy executor.
+          real_git=$(which git)
+          mkdir -p /tmp/quiet-git
+          printf '#!/bin/bash\ncase "$1" in\n  commit|add|fetch|push) exec "%s" "$1" --quiet "${@:2}" ;;\n  *) exec "%s" "$@" ;;\nesac\n' "$real_git" "$real_git" > /tmp/quiet-git/git
+          chmod +x /tmp/quiet-git/git
+          export PATH="/tmp/quiet-git:$PATH"
+
           npx nx deploy craigory-dev -c preview --directory ./dist/gh-pages-root
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,7 +65,7 @@ jobs:
           # avoiding stdout maxBuffer overflow in the deploy executor.
           real_git=$(which git)
           mkdir -p /tmp/quiet-git
-          printf '#!/bin/bash\nexec "%s" "$@" > /dev/null 2>&1\n' "$real_git" > /tmp/quiet-git/git
+          printf '#!/bin/bash\ncase "$1" in\n  commit) exec "%s" "$@" > /dev/null 2>&1 ;;\n  *) exec "%s" "$@" ;;\nesac\n' "$real_git" "$real_git" > /tmp/quiet-git/git
           chmod +x /tmp/quiet-git/git
           export PATH="/tmp/quiet-git:$PATH"
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -61,14 +61,6 @@ jobs:
           cp -r ./dist/apps/craigory-dev/client "./dist/gh-pages-root${PATH_PREFIX}"
           cp ./dist/apps/craigory-dev/client/CNAME ./dist/gh-pages-root
 
-          # Wrap git to add --quiet to commands that produce excessive output,
-          # avoiding stdout maxBuffer overflow in the deploy executor.
-          real_git=$(which git)
-          mkdir -p /tmp/quiet-git
-          printf '#!/bin/bash\ncase "$1" in\n  commit) exec "%s" "$@" > /dev/null 2>&1 ;;\n  *) exec "%s" "$@" ;;\nesac\n' "$real_git" "$real_git" > /tmp/quiet-git/git
-          chmod +x /tmp/quiet-git/git
-          export PATH="/tmp/quiet-git:$PATH"
-
           npx nx deploy craigory-dev -c preview --directory ./dist/gh-pages-root
         env:
           GH_TOKEN: ${{ secrets.DEPLOY_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -65,7 +65,7 @@ jobs:
           # avoiding stdout maxBuffer overflow in the deploy executor.
           real_git=$(which git)
           mkdir -p /tmp/quiet-git
-          printf '#!/bin/bash\ncase "$1" in\n  commit|add|fetch|push) exec "%s" "$1" --quiet "${@:2}" ;;\n  *) exec "%s" "$@" ;;\nesac\n' "$real_git" "$real_git" > /tmp/quiet-git/git
+          printf '#!/bin/bash\ncase "$1" in\n  commit|fetch|push|init) exec "%s" "$1" --quiet "${@:2}" ;;\n  *) exec "%s" "$@" ;;\nesac\n' "$real_git" "$real_git" > /tmp/quiet-git/git
           chmod +x /tmp/quiet-git/git
           export PATH="/tmp/quiet-git:$PATH"
 

--- a/apps/craigory-dev/src/data/projects.ts
+++ b/apps/craigory-dev/src/data/projects.ts
@@ -7,7 +7,7 @@ import {
   GithubProjectData,
 } from '../../pages/projects/types';
 import { isBefore, subYears } from 'date-fns';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
 import {
   existsSync,
   readFileSync,
@@ -1051,13 +1051,15 @@ async function getLocalProjects(
         readFileSync(metadataPath, 'utf-8')
       );
 
-      // Check if project has been built (try both locations)
+      // Check if project has been built (try both locations).
+      // Store only the relative path here — the baseUrl is applied in
+      // loadAllProjects so that a cached value stays correct when the
+      // PUBLIC_ENV__BASE_URL changes between builds (e.g. preview deploys).
       const monorepoDistPath = join(workspaceRoot, 'dist', 'apps', appDir);
       const projectDistPath = join(projectPath, 'dist', 'client');
-      const baseUrl = process.env.PUBLIC_ENV__BASE_URL || '';
       const deployment =
         existsSync(monorepoDistPath) || existsSync(projectDistPath)
-          ? `${baseUrl}/${appDir}`
+          ? `/${appDir}`
           : undefined;
 
       // Get README if exists
@@ -1221,6 +1223,18 @@ export async function loadAllProjects(): Promise<RepoData[]> {
     ]);
     localProjects = [...appProjects, ...packageProjects];
     writeFileSync(localCachePath, JSON.stringify(localProjects, null, 2));
+  }
+
+  // Apply the current base URL to local project deployments. This is done
+  // here (rather than at cache-write time) so that the cache — which may have
+  // been produced by an earlier build with a different PUBLIC_ENV__BASE_URL —
+  // always reflects the base URL of the current build. Without this, preview
+  // deployments at /pr/<num> would link to /<appDir> and 404.
+  const baseUrl = process.env.PUBLIC_ENV__BASE_URL || '';
+  for (const project of localProjects) {
+    if (project.deployment && project.projectPath) {
+      project.deployment = `${baseUrl}/${basename(project.projectPath)}`;
+    }
   }
 
   const mergedProjects = await normalizePublishedPackageEntries([

--- a/apps/craigory-dev/src/data/projects.ts
+++ b/apps/craigory-dev/src/data/projects.ts
@@ -1054,9 +1054,10 @@ async function getLocalProjects(
       // Check if project has been built (try both locations)
       const monorepoDistPath = join(workspaceRoot, 'dist', 'apps', appDir);
       const projectDistPath = join(projectPath, 'dist', 'client');
+      const baseUrl = process.env.PUBLIC_ENV__BASE_URL || '';
       const deployment =
         existsSync(monorepoDistPath) || existsSync(projectDistPath)
-          ? `/${appDir}`
+          ? `${baseUrl}/${appDir}`
           : undefined;
 
       // Get README if exists

--- a/package.json
+++ b/package.json
@@ -103,7 +103,8 @@
   "packageManager": "pnpm@9.12.2+sha512.22721b3a11f81661ae1ec68ce1a7b879425a1ca5b991c975b074ac220b187ce56c708fe5db69f4c962c989452eee76c82877f4ee80f474cebd61ee13461b6228",
   "pnpm": {
     "patchedDependencies": {
-      "vike": "patches/vike.patch"
+      "vike": "patches/vike.patch",
+      "nx": "patches/nx.patch"
     }
   },
   "nx": {}

--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
   "pnpm": {
     "patchedDependencies": {
       "vike": "patches/vike.patch",
-      "nx": "patches/nx.patch"
+      "nx": "patches/nx.patch",
+      "nx-github-pages": "patches/nx-github-pages.patch"
     }
   },
   "nx": {}

--- a/patches/nx-github-pages.patch
+++ b/patches/nx-github-pages.patch
@@ -1,0 +1,35 @@
+diff --git a/src/utils/exec.js b/src/utils/exec.js
+index 66bdc4a2a998b6b9ef5b797cd84f5e5982ea4780..10f68452dc284ae37063664c649c0b6da0ef079b 100644
+--- a/src/utils/exec.js
++++ b/src/utils/exec.js
+@@ -8,18 +8,23 @@ function exec(command, options) {
+         const { stdio } = options, childProcessArgs = tslib_1.__rest(options, ["stdio"]);
+         return new Promise((resolve, reject) => {
+             var _a, _b;
+-            const childProcess = (0, child_process_1.exec)(command, childProcessArgs, (error, stdout) => {
+-                if (error) {
+-                    reject(error);
++            const childProcess = (0, child_process_1.spawn)(command, { shell: true, ...childProcessArgs });
++            let stdout = '';
++            if (childProcess.stdout) {
++                childProcess.stdout.on('data', (data) => { stdout += data; });
++            }
++            if ((stdio !== null && stdio !== void 0 ? stdio : 'inherit') === 'inherit') {
++                (_a = childProcess.stdout) === null || _a === void 0 ? void 0 : _a.pipe(process.stdout);
++                (_b = childProcess.stderr) === null || _b === void 0 ? void 0 : _b.pipe(process.stderr);
++            }
++            childProcess.on('close', (code) => {
++                if (code !== 0) {
++                    reject(new Error(`Command failed with exit code ${code}: ${command}`));
+                 }
+                 else {
+                     resolve(stdout);
+                 }
+             });
+-            if ((stdio !== null && stdio !== void 0 ? stdio : 'inherit') === 'inherit') {
+-                (_a = childProcess.stdout) === null || _a === void 0 ? void 0 : _a.pipe(process.stdout);
+-                (_b = childProcess.stderr) === null || _b === void 0 ? void 0 : _b.pipe(process.stderr);
+-            }
+         });
+     });
+ }

--- a/patches/nx.patch
+++ b/patches/nx.patch
@@ -1,0 +1,33 @@
+diff --git a/src/executors/run-commands/running-tasks.js b/src/executors/run-commands/running-tasks.js
+index bed46e5655725bffab3a60e65043a1cde7e3c2f1..dc78341474b42475b49a8cc070cf00ddfe7e899a 100644
+--- a/src/executors/run-commands/running-tasks.js
++++ b/src/executors/run-commands/running-tasks.js
+@@ -241,8 +241,8 @@ class RunningNodeProcess {
+         if (streamOutput) {
+             process.stdout.write(this.terminalOutput);
+         }
+-        this.childProcess = (0, child_process_1.exec)(commandConfig.command, {
+-            maxBuffer: run_commands_impl_1.LARGE_BUFFER,
++        this.childProcess = (0, child_process_1.spawn)(commandConfig.command, {
++            shell: true,
+             env,
+             cwd,
+             windowsHide: false,
+diff --git a/src/executors/run-script/run-script.impl.js b/src/executors/run-script/run-script.impl.js
+index 4aaab78e25df8826e62ed3967f693ca9bcb71c96..256748bf19f895cb12b24ced8face575653d845b 100644
+--- a/src/executors/run-script/run-script.impl.js
++++ b/src/executors/run-script/run-script.impl.js
+@@ -34,9 +34,10 @@ async function default_1(options, context) {
+ }
+ function nodeProcess(command, cwd, env) {
+     return new Promise((res, rej) => {
+-        let cp = (0, child_process_1.exec)(command, { cwd, env, maxBuffer: LARGE_BUFFER, windowsHide: false }, (error) => {
+-            if (error) {
+-                rej(error);
++        let cp = (0, child_process_1.spawn)(command, { shell: true, cwd, env, windowsHide: false });
++        cp.on('close', (code) => {
++            if (code !== 0) {
++                rej(new Error(`Process exited with code ${code}`));
+             }
+             else {
+                 res();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ patchedDependencies:
   nx:
     hash: dmq4mqqhihc3zwqbowdax7idi4
     path: patches/nx.patch
+  nx-github-pages:
+    hash: 3j5l4jw5wd6334nrjtrvur2a6e
+    path: patches/nx-github-pages.patch
   vike:
     hash: glgnedzwnw5rvkijrtehacjmkm
     path: patches/vike.patch
@@ -235,7 +238,7 @@ importers:
         version: 19.1.0
       nx-github-pages:
         specifier: ^1.0.0
-        version: 1.2.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 1.2.0(patch_hash=3j5l4jw5wd6334nrjtrvur2a6e)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       open:
         specifier: ^11.0.0
         version: 11.0.0
@@ -21349,7 +21352,7 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  nx-github-pages@1.2.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18))):
+  nx-github-pages@1.2.0(patch_hash=3j5l4jw5wd6334nrjtrvur2a6e)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18))):
     dependencies:
       '@nx/devkit': 21.4.1(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       enquirer: 2.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
+  nx:
+    hash: dmq4mqqhihc3zwqbowdax7idi4
+    path: patches/nx.patch
   vike:
     hash: glgnedzwnw5rvkijrtehacjmkm
     path: patches/vike.patch
@@ -121,28 +124,28 @@ importers:
         version: 0.10.1
       '@nx/cypress':
         specifier: 22.5.0
-        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(cypress@15.9.0)(eslint@8.57.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)
+        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(cypress@15.9.0)(eslint@8.57.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)
       '@nx/eslint':
         specifier: 22.5.0
-        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/eslint-plugin':
         specifier: 22.5.0
-        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.9.2))(eslint-config-prettier@10.1.8(eslint@8.57.0))(eslint@8.57.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)
+        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.9.2))(eslint-config-prettier@10.1.8(eslint@8.57.0))(eslint@8.57.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)
       '@nx/jest':
         specifier: 22.5.0
-        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.18.1)(babel-plugin-macros@3.1.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.18.1)(typescript@5.9.2))(typescript@5.9.2)
+        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.18.1)(babel-plugin-macros@3.1.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.18.1)(typescript@5.9.2))(typescript@5.9.2)
       '@nx/js':
         specifier: 22.5.0
-        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/react':
         specifier: 22.5.0
-        version: 22.5.0(@babel/core@7.28.3)(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)
+        version: 22.5.0(@babel/core@7.28.3)(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)
       '@nx/vite':
         specifier: 22.5.0
-        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)
+        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)
       '@nx/vitest':
         specifier: 22.5.0
-        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)
+        version: 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)
       '@nx/workspace':
         specifier: 22.5.0
         version: 22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18))
@@ -226,13 +229,13 @@ importers:
         version: 22.1.0
       nx:
         specifier: 22.5.0
-        version: 22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18))
+        version: 22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18))
       nx-cloud:
         specifier: 19.1.0
         version: 19.1.0
       nx-github-pages:
         specifier: ^1.0.0
-        version: 1.2.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+        version: 1.2.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       open:
         specifier: ^11.0.0
         version: 11.0.0
@@ -13920,11 +13923,11 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@nx/cypress@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(cypress@15.9.0)(eslint@8.57.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)':
+  '@nx/cypress@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(cypress@15.9.0)(eslint@8.57.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)':
     dependencies:
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/eslint': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/eslint': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.2)
       detect-port: 1.6.1
       semver: 7.7.2
@@ -13944,33 +13947,33 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/devkit@21.4.1(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@nx/devkit@21.4.1(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       ejs: 3.1.10
       enquirer: 2.3.6
       ignore: 5.3.2
       minimatch: 9.0.3
-      nx: 22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18))
+      nx: 22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18))
       semver: 7.7.2
       tmp: 0.2.5
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/devkit@22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@nx/devkit@22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@zkochan/js-yaml': 0.0.7
       ejs: 3.1.10
       enquirer: 2.3.6
       minimatch: 10.1.1
-      nx: 22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18))
+      nx: 22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18))
       semver: 7.7.2
       tslib: 2.8.1
       yargs-parser: 21.1.1
 
-  '@nx/eslint-plugin@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.9.2))(eslint-config-prettier@10.1.8(eslint@8.57.0))(eslint@8.57.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)':
+  '@nx/eslint-plugin@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@typescript-eslint/parser@7.16.1(eslint@8.57.0)(typescript@5.9.2))(eslint-config-prettier@10.1.8(eslint@8.57.0))(eslint@8.57.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)':
     dependencies:
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.2)
       '@typescript-eslint/parser': 7.16.1(eslint@8.57.0)(typescript@5.9.2)
       '@typescript-eslint/type-utils': 8.42.0(eslint@8.57.0)(typescript@5.9.2)
@@ -13994,10 +13997,10 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/eslint@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@nx/eslint@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       eslint: 8.57.0
       semver: 7.7.2
       tslib: 2.8.1
@@ -14013,12 +14016,12 @@ snapshots:
       - supports-color
       - verdaccio
 
-  '@nx/jest@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.18.1)(babel-plugin-macros@3.1.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.18.1)(typescript@5.9.2))(typescript@5.9.2)':
+  '@nx/jest@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.18.1)(babel-plugin-macros@3.1.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.18.1)(typescript@5.9.2))(typescript@5.9.2)':
     dependencies:
       '@jest/reporters': 30.1.3
       '@jest/test-result': 30.1.3
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.2)
       identity-obj-proxy: 3.0.0
       jest-config: 30.1.3(@types/node@22.18.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/node@22.18.1)(typescript@5.9.2))
@@ -14045,7 +14048,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/js@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@nx/js@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
       '@babel/core': 7.28.3
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.28.3)
@@ -14054,7 +14057,7 @@ snapshots:
       '@babel/preset-env': 7.28.3(@babel/core@7.28.3)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.3)
       '@babel/runtime': 7.28.3
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@nx/workspace': 22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18))
       '@zkochan/js-yaml': 0.0.7
       babel-plugin-const-enum: 1.2.0(@babel/core@7.28.3)
@@ -14081,14 +14084,14 @@ snapshots:
       - nx
       - supports-color
 
-  '@nx/module-federation@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)':
+  '@nx/module-federation@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)':
     dependencies:
       '@module-federation/enhanced': 0.21.6(@rspack/core@1.6.8(@swc/helpers@0.5.18))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/node': 2.7.32(@rspack/core@1.6.8(@swc/helpers@0.5.18))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(webpack@5.101.3(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@module-federation/sdk': 0.21.6
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/web': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/web': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
       express: 4.21.2
       http-proxy-middleware: 3.0.5
@@ -14144,14 +14147,14 @@ snapshots:
   '@nx/nx-win32-x64-msvc@22.5.0':
     optional: true
 
-  '@nx/react@22.5.0(@babel/core@7.28.3)(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)':
+  '@nx/react@22.5.0(@babel/core@7.28.3)(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(@types/babel__core@7.20.5)(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)':
     dependencies:
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/eslint': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/module-federation': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
-      '@nx/rollup': 22.5.0(@babel/core@7.28.3)(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/babel__core@7.20.5)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)
-      '@nx/web': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/eslint': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@8.57.0)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/module-federation': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@swc/helpers@0.5.18)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(typescript@5.9.2)
+      '@nx/rollup': 22.5.0(@babel/core@7.28.3)(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/babel__core@7.20.5)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)
+      '@nx/web': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.2)
       '@svgr/webpack': 8.1.0(typescript@5.9.2)
       express: 4.21.2
@@ -14161,7 +14164,7 @@ snapshots:
       semver: 7.7.2
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/vite': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)
+      '@nx/vite': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)
     transitivePeerDependencies:
       - '@babel/core'
       - '@babel/traverse'
@@ -14187,10 +14190,10 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/rollup@22.5.0(@babel/core@7.28.3)(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/babel__core@7.20.5)(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)':
+  '@nx/rollup@22.5.0(@babel/core@7.28.3)(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(@types/babel__core@7.20.5)(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)':
     dependencies:
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@rollup/plugin-babel': 6.0.4(@babel/core@7.28.3)(@types/babel__core@7.20.5)(rollup@4.50.0)
       '@rollup/plugin-commonjs': 25.0.8(rollup@4.50.0)
       '@rollup/plugin-image': 3.0.3(rollup@4.50.0)
@@ -14218,11 +14221,11 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vite@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)':
+  '@nx/vite@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)':
     dependencies:
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/vitest': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/vitest': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.2)
       ajv: 8.17.1
       enquirer: 2.3.6
@@ -14242,10 +14245,10 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/vitest@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)':
+  '@nx/vitest@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))(typescript@5.9.2)(vite@7.1.5(@types/node@22.18.1)(jiti@2.5.1)(lightningcss@1.30.1)(sass@1.92.0)(terser@5.44.0)(tsx@4.21.0))(vitest@4.0.9)':
     dependencies:
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.2)
       semver: 7.7.2
       tslib: 2.8.1
@@ -14262,10 +14265,10 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/web@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
+  '@nx/web@22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))':
     dependencies:
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
-      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/js': 22.5.0(@babel/traverse@7.28.3)(@swc/core@1.15.8(@swc/helpers@0.5.18))(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       detect-port: 1.6.1
       http-server: 14.1.1
       picocolors: 1.1.1
@@ -14281,11 +14284,11 @@ snapshots:
 
   '@nx/workspace@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18))':
     dependencies:
-      '@nx/devkit': 22.5.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 22.5.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       '@zkochan/js-yaml': 0.0.7
       chalk: 4.1.2
       enquirer: 2.3.6
-      nx: 22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18))
+      nx: 22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18))
       picomatch: 4.0.2
       semver: 7.7.2
       tslib: 2.8.1
@@ -21346,15 +21349,15 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  nx-github-pages@1.2.0(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18))):
+  nx-github-pages@1.2.0(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18))):
     dependencies:
-      '@nx/devkit': 21.4.1(nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)))
+      '@nx/devkit': 21.4.1(nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)))
       enquirer: 2.4.1
       tslib: 2.8.1
     transitivePeerDependencies:
       - nx
 
-  nx@22.5.0(@swc/core@1.15.8(@swc/helpers@0.5.18)):
+  nx@22.5.0(patch_hash=dmq4mqqhihc3zwqbowdax7idi4)(@swc/core@1.15.8(@swc/helpers@0.5.18)):
     dependencies:
       '@napi-rs/wasm-runtime': 0.2.4
       '@yarnpkg/lockfile': 1.1.0


### PR DESCRIPTION
## Summary
- Prefixes local project deployment URLs with `PUBLIC_ENV__BASE_URL` so preview deployments link to the correct preview paths (e.g. `/pr/42/alt-codes` instead of `/alt-codes`)
- No behavior change in production where `PUBLIC_ENV__BASE_URL` is unset

## Test plan
- [ ] Verify preview deployment "Launch" links on the tools page point to `/pr/{number}/{appDir}`
- [ ] Verify production deployment URLs remain `/{appDir}` (no regression)