### PR TITLE
feat(craigory-dev): add sort options to projects page

### DIFF
--- a/apps/craigory-dev/pages/projects/+Page.tsx
+++ b/apps/craigory-dev/pages/projects/+Page.tsx
@@ -8,7 +8,7 @@ import { RepoData } from './types';
 import { FilterBar } from './components/filter-bar';
 import { ProjectCard } from './components/ProjectCard';
 import { ContentMarker } from '../../src/shared-components/content-marker';
-import { differenceInDays } from 'date-fns';
+import { sortByRelevance } from './components/sort-functions';
 
 export function Page() {
   const { projects } = useData<{ projects: RepoData[] }>();
@@ -20,7 +20,7 @@ export function Page() {
 
   const [sortFn, setSortFn] = useState<
     (projects: RepoData[]) => (a: RepoData, b: RepoData) => number
-  >(() => calculateRelevance);
+  >(() => sortByRelevance);
 
   const [sortedProjects, setSortedProjects] = useState<RepoData[]>(() => {
     const fn = sortFn(projects);
@@ -73,27 +73,4 @@ export function Page() {
       ))}
     </>
   );
-}
-
-const calculateRelevance = (projects: RepoData[]) => {
-  const relevanceMap = new Map<string, number>();
-  for (const project of projects) {
-    relevanceMap.set(project.repo, calculateRelevanceForProject(project));
-  }
-  return (a: RepoData, b: RepoData) => {
-    return relevanceMap.get(b.repo) ?? 0 - (relevanceMap.get(a.repo) ?? 0);
-  };
-};
-
-function calculateRelevanceForProject(p: RepoData) {
-  // popularity metrics, based on stars + published package downloads
-  const stars = p.stars ?? 0;
-  const downloads = Object.values(p.publishedPackages ?? {}).reduce(
-    (acc, { downloads }) => acc + downloads,
-    0
-  );
-  // Recency metrics
-  const lastCommit = differenceInDays(new Date(), new Date(p.lastCommit ?? ''));
-
-  return stars + downloads / 100 + 100 / lastCommit;
 }

--- a/apps/craigory-dev/pages/projects/+Page.tsx
+++ b/apps/craigory-dev/pages/projects/+Page.tsx
@@ -24,7 +24,7 @@ export function Page() {
 
   const [sortedProjects, setSortedProjects] = useState<RepoData[]>(() => {
     const fn = sortFn(projects);
-    return filteredProjects.sort(fn);
+    return [...filteredProjects].sort(fn);
   });
 
   useEffect(() => {
@@ -36,7 +36,7 @@ export function Page() {
   useEffect(() => {
     if (filteredProjects) {
       const fn = sortFn(filteredProjects);
-      setSortedProjects(filteredProjects.sort(fn));
+      setSortedProjects([...filteredProjects].sort(fn));
     }
   }, [filteredProjects, sortFn]);
 

--- a/apps/craigory-dev/pages/projects/components/filter-bar.tsx
+++ b/apps/craigory-dev/pages/projects/components/filter-bar.tsx
@@ -7,6 +7,7 @@ import { FilterDropdown } from './filter-dropdown';
 import { IoClose } from 'react-icons/io5';
 
 import styles from './filter-bar.module.scss';
+import { SORT_OPTIONS, SortFactory } from './sort-functions';
 
 export type FilterFn = (p: RepoData) => boolean;
 
@@ -192,6 +193,33 @@ export function FilterBar({
   return (
     <table {...tableProps} className={styles['filter-table']}>
       <tbody>
+        <tr>
+          <td></td>
+          <td>
+            <label htmlFor="sort-by">Sort by</label>
+          </td>
+          <td>
+            <select
+              id="sort-by"
+              defaultValue={SORT_OPTIONS[0].value}
+              onChange={(e) => {
+                const selected = SORT_OPTIONS.find(
+                  (o) => o.value === e.target.value
+                );
+                if (selected) {
+                  const fn: SortFactory = selected.fn;
+                  onSetSort(() => fn);
+                }
+              }}
+            >
+              {SORT_OPTIONS.map((o) => (
+                <option key={o.value} value={o.value}>
+                  {o.label}
+                </option>
+              ))}
+            </select>
+          </td>
+        </tr>
         {Array.from(filters.values()).map((filter) => (
           <tr key={filter.id}>
             <td>

--- a/apps/craigory-dev/pages/projects/components/sort-functions.ts
+++ b/apps/craigory-dev/pages/projects/components/sort-functions.ts
@@ -1,0 +1,53 @@
+import { differenceInDays } from 'date-fns';
+import { RepoData } from '../types';
+
+export type SortFactory = (
+  projects: RepoData[]
+) => (a: RepoData, b: RepoData) => number;
+
+function totalDownloads(p: RepoData): number {
+  return Object.values(p.publishedPackages ?? {}).reduce(
+    (acc, { downloads }) => acc + downloads,
+    0
+  );
+}
+
+function lastCommitTime(p: RepoData): number {
+  const raw = p.lastCommit;
+  if (!raw) return 0;
+  const t = new Date(raw).getTime();
+  return Number.isNaN(t) ? 0 : t;
+}
+
+export const sortByRelevance: SortFactory = (projects) => {
+  const relevance = new Map<string, number>();
+  for (const p of projects) {
+    const stars = p.stars ?? 0;
+    const downloads = totalDownloads(p);
+    const daysSinceCommit = p.lastCommit
+      ? Math.max(differenceInDays(new Date(), new Date(p.lastCommit)), 1)
+      : Number.POSITIVE_INFINITY;
+    relevance.set(p.repo, stars + downloads / 100 + 100 / daysSinceCommit);
+  }
+  return (a, b) => (relevance.get(b.repo) ?? 0) - (relevance.get(a.repo) ?? 0);
+};
+
+export const sortByStars: SortFactory = () => (a, b) =>
+  (b.stars ?? 0) - (a.stars ?? 0);
+
+export const sortByDownloads: SortFactory = () => (a, b) =>
+  totalDownloads(b) - totalDownloads(a);
+
+export const sortByLastCommit: SortFactory = () => (a, b) =>
+  lastCommitTime(b) - lastCommitTime(a);
+
+export const SORT_OPTIONS: {
+  value: string;
+  label: string;
+  fn: SortFactory;
+}[] = [
+  { value: 'relevance', label: 'Relevance', fn: sortByRelevance },
+  { value: 'stars', label: 'Stars', fn: sortByStars },
+  { value: 'downloads', label: 'Downloads', fn: sortByDownloads },
+  { value: 'last-commit', label: 'Last Commit', fn: sortByLastCommit },
+];


### PR DESCRIPTION
## Summary
- Adds a "Sort by" dropdown to the projects page filter bar: Relevance (default), Stars, Downloads, Last Commit.
- Extracts sort functions into a shared `sort-functions.ts` module with a registry of sort factories (one place to add future sort options).
- Wires the previously-unused `onSetSort` prop on `FilterBar` to the new dropdown; also fixes an operator-precedence bug in the original relevance comparator that was uncovered while extracting it.

## Test plan
- [ ] Load `/projects` — default order (Relevance) is unchanged vs. main
- [ ] Switch dropdown to **Stars** — order matches `stars` desc; projects with no stars fall to the end
- [ ] Switch to **Downloads** — order matches summed `publishedPackages[].downloads` desc; projects with no packages sink
- [ ] Switch to **Last Commit** — newest commit first; projects with missing `lastCommit` sink
- [ ] Add/remove filters while a non-default sort is active — order stays correct as filter set changes