### PR TITLE
feat(craigory-dev): show contributed-to projects with a Contributor badge

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,9 +2,6 @@ name: PR Checks + Deployment
 
 on:
   pull_request:
-    branches:
-      - main
-      - preview
 
 jobs:
   deploy:

--- a/apps/craigory-dev/pages/projects/+Page.tsx
+++ b/apps/craigory-dev/pages/projects/+Page.tsx
@@ -56,21 +56,36 @@ export function Page() {
         onSetSort={setSortFn}
         style={{ maxWidth: '45rem' }}
       ></FilterBar>
-      {sortedProjects.map((p, idx) => (
-        <div key={p.repo} className="project-wrapper">
-          <div className="project-header">
-            <a href={`#${p.repo}`} className="content-marker-link">
-              <ContentMarker />
-            </a>
-            <h2 id={p.repo}>{p.repo}</h2>
+      {sortedProjects.map((p, idx) => {
+        const isContributor = p.type === 'github' && p.role === 'contributor';
+        const anchor = isContributor
+          ? p.data.full_name.replace('/', '-')
+          : p.repo;
+        const title = isContributor ? p.data.full_name : p.repo;
+        return (
+          <div key={anchor} className="project-wrapper">
+            <div className="project-header">
+              <a href={`#${anchor}`} className="content-marker-link">
+                <ContentMarker />
+              </a>
+              <h2 id={anchor}>{title}</h2>
+              {isContributor && (
+                <span
+                  className="role-badge"
+                  title="I contribute to this project but don't own it."
+                >
+                  Contributor
+                </span>
+              )}
+            </div>
+            {p.description && (
+              <p className="project-description">{p.description}</p>
+            )}
+            <ProjectCard project={p} />
+            {idx < projects.length - 1 && <hr />}
           </div>
-          {p.description && (
-            <p className="project-description">{p.description}</p>
-          )}
-          <ProjectCard project={p} />
-          {idx < projects.length - 1 && <hr />}
-        </div>
-      ))}
+        );
+      })}
     </>
   );
 }

--- a/apps/craigory-dev/pages/projects/data-loader.spec.ts
+++ b/apps/craigory-dev/pages/projects/data-loader.spec.ts
@@ -26,12 +26,6 @@ function createOctokitMock() {
     paginate = {
       iterator: vi.fn(),
     };
-    hook = {
-      wrap: vi.fn(),
-      before: vi.fn(),
-      after: vi.fn(),
-      error: vi.fn(),
-    };
   };
 }
 

--- a/apps/craigory-dev/pages/projects/data-loader.spec.ts
+++ b/apps/craigory-dev/pages/projects/data-loader.spec.ts
@@ -26,6 +26,12 @@ function createOctokitMock() {
     paginate = {
       iterator: vi.fn(),
     };
+    hook = {
+      wrap: vi.fn(),
+      before: vi.fn(),
+      after: vi.fn(),
+      error: vi.fn(),
+    };
   };
 }
 

--- a/apps/craigory-dev/pages/projects/styles.scss
+++ b/apps/craigory-dev/pages/projects/styles.scss
@@ -7,11 +7,27 @@
 .project-header {
   display: flex;
   align-items: baseline;
+  flex-wrap: wrap;
   gap: 0.5rem;
 
   h2 {
     margin: 0;
   }
+}
+
+.role-badge {
+  font-size: 0.75rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  color: #555;
+  background-color: #f0ead6;
+  border: 1px solid #d8cfa8;
+  border-radius: 999px;
+  padding: 0.15rem 0.55rem;
+  line-height: 1.4;
+  white-space: nowrap;
+  cursor: help;
 }
 
 .content-marker-link {

--- a/apps/craigory-dev/pages/projects/types.ts
+++ b/apps/craigory-dev/pages/projects/types.ts
@@ -24,6 +24,7 @@ export type BaseProjectData = {
 export type GithubProjectData = BaseProjectData & {
   type: 'github';
   data: GithubRepo;
+  role?: 'owner' | 'contributor';
 };
 
 export type LocalProjectData = BaseProjectData & {

--- a/apps/craigory-dev/src/data/projects.ts
+++ b/apps/craigory-dev/src/data/projects.ts
@@ -30,29 +30,36 @@ const client = new Octokit({
 const publicClient = new Octokit();
 const authBlockedOwners = new Set<string>();
 
-function ownerFromRequestOptions(
-  options: Record<string, unknown> | undefined
-): string | undefined {
-  if (!options) return undefined;
-  if (typeof options.owner === 'string') return options.owner;
-  if (typeof options.username === 'string') return options.username;
-  if (typeof options.org === 'string') return options.org;
-  if (typeof options.url === 'string') {
-    const match = options.url.match(/\/(?:repos|users|orgs)\/([^/]+)/);
-    if (match) return match[1];
-  }
-  return undefined;
+let githubRequestCount = 0;
+function trackRequestCount(octokit: Octokit) {
+  const original = octokit.request;
+  const patched: typeof octokit.request = ((
+    ...args: Parameters<typeof octokit.request>
+  ) => {
+    githubRequestCount++;
+    return original(...args);
+  }) as Partial<typeof octokit.request> as typeof octokit.request;
+  Object.assign(patched, original);
+  octokit.request = patched;
 }
+trackRequestCount(client);
+trackRequestCount(publicClient);
 
-client.hook.wrap('request', async (request, options) => {
-  const owner = ownerFromRequestOptions(
-    options as unknown as Record<string, unknown>
-  );
+/**
+ * Runs a GitHub call with the authenticated client, falling back to the
+ * unauthenticated client if the owner's org rejects our fine-grained PAT.
+ * Replaces the previous request-hook approach so each call site explicitly
+ * declares which owner it's talking to.
+ */
+async function withAuthFallback<T>(
+  owner: string | undefined,
+  fn: (octokit: Octokit) => Promise<T>
+): Promise<T> {
   if (owner && authBlockedOwners.has(owner)) {
-    return publicClient.request(options);
+    return fn(publicClient);
   }
   try {
-    return await request(options);
+    return await fn(client);
   } catch (err) {
     const message = (err as { message?: string })?.message ?? '';
     if (message.includes('organization forbids access via a fine-grained')) {
@@ -62,24 +69,11 @@ client.hook.wrap('request', async (request, options) => {
           `'${owner}' rejects fine-grained PAT; falling back to unauthenticated API for this and future requests to that owner.`
         );
       }
-      return publicClient.request(options);
+      return fn(publicClient);
     }
     throw err;
   }
-});
-
-let githubRequestCount = 0;
-const originalRequest = client.request;
-const patchedRequest: typeof client.request = ((
-  ...args: Parameters<typeof client.request>
-) => {
-  githubRequestCount++;
-  return originalRequest(...args);
-}) as Partial<typeof client.request> as typeof client.request;
-
-Object.assign(patchedRequest, originalRequest);
-
-client.request = patchedRequest;
+}
 
 // ============================================================================
 // NPM Package Types and Functions
@@ -202,7 +196,8 @@ async function requestWithRetry<T>(
  * Much more efficient than traversing each repo's file tree.
  */
 async function findPackageJsonFiles(
-  searchQuery: string
+  searchQuery: string,
+  owner?: string
 ): Promise<PackageJsonLocation[]> {
   const results: PackageJsonLocation[] = [];
   let page = 1;
@@ -211,11 +206,13 @@ async function findPackageJsonFiles(
 
   while (hasMore && page * perPage < 1000) {
     const response = await requestWithRetry(() =>
-      client.request('GET /search/code', {
-        q: `filename:package.json ${searchQuery}`,
-        per_page: perPage,
-        page,
-      })
+      withAuthFallback(owner, (oct) =>
+        oct.request('GET /search/code', {
+          q: `filename:package.json ${searchQuery}`,
+          per_page: perPage,
+          page,
+        })
+      )
     );
 
     for (const item of response.data.items) {
@@ -268,7 +265,10 @@ async function findAllPackageJsonLocations(): Promise<PackageJsonLocation[]> {
   const allLocations: PackageJsonLocation[] = [];
 
   // Search user's repos
-  const userPackages = await findPackageJsonFiles('user:agentender');
+  const userPackages = await findPackageJsonFiles(
+    'user:agentender',
+    'agentender'
+  );
   allLocations.push(...userPackages);
 
   // Search additional repos (including contributor repos — getPublishedPackages
@@ -276,7 +276,8 @@ async function findAllPackageJsonLocations(): Promise<PackageJsonLocation[]> {
   // published to npm, so the resulting list stays small).
   for (const repo of ADDITIONAL_REPOS) {
     const repoPackages = await findPackageJsonFiles(
-      `repo:${repo.owner}/${repo.name}`
+      `repo:${repo.owner}/${repo.name}`,
+      repo.owner
     );
     allLocations.push(...repoPackages);
   }
@@ -616,10 +617,12 @@ async function getAllRepos(
   for (const chunk of chunks) {
     const chunkData = await Promise.all(
       chunk.map(async (repo) => {
-        const githubRepo = await client.rest.repos.get({
-          owner: repo.owner,
-          repo: repo.name,
-        });
+        const githubRepo = await withAuthFallback(repo.owner, (oct) =>
+          oct.rest.repos.get({
+            owner: repo.owner,
+            repo: repo.name,
+          })
+        );
         const fullName = `${repo.owner}/${repo.name}`;
         const packageJsons = packageJsonsByRepo.get(fullName) || [];
         return processRepo(
@@ -711,8 +714,10 @@ async function getReadme(repo: GithubRepo) {
   try {
     return repo.default_branch
       ? (
-          await client.request(
-            `GET https://raw.githubusercontent.com/${repo.owner.login}/${repo.name}/${repo.default_branch}/README.md`
+          await withAuthFallback(repo.owner.login, (oct) =>
+            oct.request(
+              `GET https://raw.githubusercontent.com/${repo.owner.login}/${repo.name}/${repo.default_branch}/README.md`
+            )
           )
         ).data
       : null;
@@ -726,11 +731,13 @@ async function getLastCommit(repo: GithubRepo) {
     return null;
   }
   try {
-    const lastCommit = await client.rest.repos.getCommit({
-      owner: repo.owner.login,
-      repo: repo.name,
-      ref: repo.default_branch,
-    });
+    const lastCommit = await withAuthFallback(repo.owner.login, (oct) =>
+      oct.rest.repos.getCommit({
+        owner: repo.owner.login,
+        repo: repo.name,
+        ref: repo.default_branch,
+      })
+    );
     return lastCommit.data?.commit.author?.date;
   } catch {
     return null;
@@ -740,10 +747,12 @@ async function getLastCommit(repo: GithubRepo) {
 const LANGUAGE_PERCENTAGE_THRESHOLD = 0.01;
 async function getLanguages(repo: GithubRepo) {
   try {
-    const languages = await client.rest.repos.listLanguages({
-      owner: repo.owner.login,
-      repo: repo.name,
-    });
+    const languages = await withAuthFallback(repo.owner.login, (oct) =>
+      oct.rest.repos.listLanguages({
+        owner: repo.owner.login,
+        repo: repo.name,
+      })
+    );
     let totalBytes = 0;
     const results: Record<string, number> = {};
     for (const lang in languages.data) {
@@ -793,21 +802,25 @@ async function findRepositoryDeployment(repo: GithubRepo) {
   let url = repo.homepage;
   if (!url) {
     // Only fetch the most recent 5 deployments to reduce API calls
-    const deployments = await client.rest.repos.listDeployments({
-      owner: repo.owner.login,
-      repo: repo.name,
-      per_page: 5,
-    });
+    const deployments = await withAuthFallback(repo.owner.login, (oct) =>
+      oct.rest.repos.listDeployments({
+        owner: repo.owner.login,
+        repo: repo.name,
+        per_page: 5,
+      })
+    );
 
     // Process deployments in parallel instead of sequentially
     const statusPromises = deployments.data.map(async (deployment) => {
       try {
-        const status = await client.rest.repos.listDeploymentStatuses({
-          owner: 'agentender',
-          repo: repo.name,
-          deployment_id: deployment.id,
-          per_page: 1, // Only get the latest status
-        });
+        const status = await withAuthFallback(repo.owner.login, (oct) =>
+          oct.rest.repos.listDeploymentStatuses({
+            owner: 'agentender',
+            repo: repo.name,
+            deployment_id: deployment.id,
+            per_page: 1, // Only get the latest status
+          })
+        );
         const latestStatus = status.data[0];
         if (latestStatus && latestStatus.state === 'success') {
           return latestStatus.environment_url ?? latestStatus.target_url;
@@ -864,7 +877,9 @@ async function getPublishedPackages(
     const results = await Promise.all(
       batch.map(async (loc) => {
         try {
-          const fileContents = await client.request(loc.gitUrl);
+          const fileContents = await withAuthFallback(repo.owner.login, (oct) =>
+            oct.request(loc.gitUrl)
+          );
           const result = fileContents.data as { content?: string };
           if (result.content) {
             const decodedContent = JSON.parse(

--- a/apps/craigory-dev/src/data/projects.ts
+++ b/apps/craigory-dev/src/data/projects.ts
@@ -125,6 +125,35 @@ interface PackageJsonManifest {
 }
 
 /**
+ * GitHub's /search/code endpoint is sharded and eventually consistent — a
+ * shard that's re-indexing can return 404 (or 5xx) for an otherwise valid
+ * query. Retry with exponential backoff so a transient bad shard doesn't
+ * fail the whole build.
+ */
+async function requestWithRetry<T>(
+  fn: () => Promise<T>,
+  attempts = 4
+): Promise<T> {
+  let lastErr: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await fn();
+    } catch (err) {
+      lastErr = err;
+      const status = (err as { status?: number })?.status;
+      const retryable = status === 404 || status === 502 || status === 503;
+      if (!retryable || i === attempts - 1) throw err;
+      const waitMs = 1000 * 2 ** i + Math.random() * 500;
+      console.warn(
+        `GitHub request returned ${status}; retrying in ${Math.round(waitMs)}ms (attempt ${i + 2}/${attempts})`
+      );
+      await new Promise((r) => setTimeout(r, waitMs));
+    }
+  }
+  throw lastErr;
+}
+
+/**
  * Uses GitHub code search to find all package.json files across repos.
  * Much more efficient than traversing each repo's file tree.
  */
@@ -137,11 +166,13 @@ async function findPackageJsonFiles(
   let hasMore = true;
 
   while (hasMore && page * perPage < 1000) {
-    const response = await client.request('GET /search/code', {
-      q: `filename:package.json ${searchQuery}`,
-      per_page: perPage,
-      page,
-    });
+    const response = await requestWithRetry(() =>
+      client.request('GET /search/code', {
+        q: `filename:package.json ${searchQuery}`,
+        per_page: perPage,
+        page,
+      })
+    );
 
     for (const item of response.data.items) {
       results.push({

--- a/apps/craigory-dev/src/data/projects.ts
+++ b/apps/craigory-dev/src/data/projects.ts
@@ -271,8 +271,11 @@ async function findAllPackageJsonLocations(): Promise<PackageJsonLocation[]> {
   const userPackages = await findPackageJsonFiles('user:agentender');
   allLocations.push(...userPackages);
 
-  // Search additional repos
+  // Search additional repos. Skip contributor repos — their packages
+  // aren't ours to advertise, and for large repos (e.g. nrwl/nx) indexing
+  // every package.json balloons memory during the SSG build.
   for (const repo of ADDITIONAL_REPOS) {
+    if (repo.role === 'contributor') continue;
     const repoPackages = await findPackageJsonFiles(
       `repo:${repo.owner}/${repo.name}`
     );
@@ -664,14 +667,23 @@ async function processRepo(
   // Skip expensive API calls for repos with a homepage already set
   const shouldCheckDeployment = !repo.homepage;
 
+  // Contributor repos are curated by hand, so we skip:
+  //  - README: only used for auto-filtering owned repos, and big READMEs
+  //    (e.g. nrwl/nx) bloat the SSG data payload.
+  //  - publishedPackages: those aren't ours to list, and indexing every
+  //    package.json in a large monorepo OOMs the build.
+  const isContributor = role === 'contributor';
+
   const [readme, deployment, lastCommit, publishedPackages, languages] =
     await Promise.all([
-      getReadme(repo),
+      isContributor ? Promise.resolve(undefined) : getReadme(repo),
       shouldCheckDeployment
         ? findRepositoryDeployment(repo)
         : Promise.resolve(repo.homepage ?? undefined),
       getLastCommit(repo),
-      getPublishedPackages(repo, packageJsonLocations),
+      isContributor
+        ? Promise.resolve(undefined)
+        : getPublishedPackages(repo, packageJsonLocations),
       getLanguages(repo),
     ]);
 

--- a/apps/craigory-dev/src/data/projects.ts
+++ b/apps/craigory-dev/src/data/projects.ts
@@ -271,11 +271,10 @@ async function findAllPackageJsonLocations(): Promise<PackageJsonLocation[]> {
   const userPackages = await findPackageJsonFiles('user:agentender');
   allLocations.push(...userPackages);
 
-  // Search additional repos. Skip contributor repos — their packages
-  // aren't ours to advertise, and for large repos (e.g. nrwl/nx) indexing
-  // every package.json balloons memory during the SSG build.
+  // Search additional repos (including contributor repos — getPublishedPackages
+  // filters the fetched package.json set down to only names that are actually
+  // published to npm, so the resulting list stays small).
   for (const repo of ADDITIONAL_REPOS) {
-    if (repo.role === 'contributor') continue;
     const repoPackages = await findPackageJsonFiles(
       `repo:${repo.owner}/${repo.name}`
     );
@@ -667,11 +666,9 @@ async function processRepo(
   // Skip expensive API calls for repos with a homepage already set
   const shouldCheckDeployment = !repo.homepage;
 
-  // Contributor repos are curated by hand, so we skip:
-  //  - README: only used for auto-filtering owned repos, and big READMEs
-  //    (e.g. nrwl/nx) bloat the SSG data payload.
-  //  - publishedPackages: those aren't ours to list, and indexing every
-  //    package.json in a large monorepo OOMs the build.
+  // Contributor repos are hand-curated, so we skip the README fetch: it's
+  // only used as an auto-filter signal for owned repos, and large READMEs
+  // (e.g. nrwl/nx) bloat the SSG data payload with tens of KB of prose.
   const isContributor = role === 'contributor';
 
   const [readme, deployment, lastCommit, publishedPackages, languages] =
@@ -681,9 +678,7 @@ async function processRepo(
         ? findRepositoryDeployment(repo)
         : Promise.resolve(repo.homepage ?? undefined),
       getLastCommit(repo),
-      isContributor
-        ? Promise.resolve(undefined)
-        : getPublishedPackages(repo, packageJsonLocations),
+      getPublishedPackages(repo, packageJsonLocations),
       getLanguages(repo),
     ]);
 

--- a/apps/craigory-dev/src/data/projects.ts
+++ b/apps/craigory-dev/src/data/projects.ts
@@ -24,6 +24,50 @@ const client = new Octokit({
   auth: process.env.GITHUB_TOKEN ?? process.env.GH_TOKEN,
 });
 
+// Some orgs (e.g. 'nrwl') block fine-grained PATs by policy — even for reads
+// of public data. Since the data we're fetching is all public, fall back to
+// an unauthenticated client for any owner that rejects our token.
+const publicClient = new Octokit();
+const authBlockedOwners = new Set<string>();
+
+function ownerFromRequestOptions(
+  options: Record<string, unknown> | undefined
+): string | undefined {
+  if (!options) return undefined;
+  if (typeof options.owner === 'string') return options.owner;
+  if (typeof options.username === 'string') return options.username;
+  if (typeof options.org === 'string') return options.org;
+  if (typeof options.url === 'string') {
+    const match = options.url.match(/\/(?:repos|users|orgs)\/([^/]+)/);
+    if (match) return match[1];
+  }
+  return undefined;
+}
+
+client.hook.wrap('request', async (request, options) => {
+  const owner = ownerFromRequestOptions(
+    options as unknown as Record<string, unknown>
+  );
+  if (owner && authBlockedOwners.has(owner)) {
+    return publicClient.request(options);
+  }
+  try {
+    return await request(options);
+  } catch (err) {
+    const message = (err as { message?: string })?.message ?? '';
+    if (message.includes('organization forbids access via a fine-grained')) {
+      if (owner) {
+        authBlockedOwners.add(owner);
+        console.warn(
+          `'${owner}' rejects fine-grained PAT; falling back to unauthenticated API for this and future requests to that owner.`
+        );
+      }
+      return publicClient.request(options);
+    }
+    throw err;
+  }
+});
+
 let githubRequestCount = 0;
 const originalRequest = client.request;
 const patchedRequest: typeof client.request = ((

--- a/apps/craigory-dev/src/data/projects.ts
+++ b/apps/craigory-dev/src/data/projects.ts
@@ -208,10 +208,21 @@ async function findAllPackageJsonLocations(): Promise<PackageJsonLocation[]> {
   return allLocations;
 }
 
-const ADDITIONAL_REPOS = [
+type AdditionalRepo = {
+  owner: string;
+  name: string;
+  role?: 'owner' | 'contributor';
+};
+
+const ADDITIONAL_REPOS: AdditionalRepo[] = [
   {
     owner: 'nx-dotnet',
     name: 'nx-dotnet',
+  },
+  {
+    owner: 'nrwl',
+    name: 'nx',
+    role: 'contributor',
   },
 ];
 
@@ -523,10 +534,7 @@ async function getAllRepos(
       }
       return acc;
     },
-    [[]] as {
-      owner: string;
-      name: string;
-    }[][]
+    [[]] as AdditionalRepo[][]
   );
   for (const chunk of chunks) {
     const chunkData = await Promise.all(
@@ -537,7 +545,11 @@ async function getAllRepos(
         });
         const fullName = `${repo.owner}/${repo.name}`;
         const packageJsons = packageJsonsByRepo.get(fullName) || [];
-        return processRepo(githubRepo.data as GithubRepo, packageJsons);
+        return processRepo(
+          githubRepo.data as GithubRepo,
+          packageJsons,
+          repo.role ?? 'owner'
+        );
       })
     );
     repos.push(...(chunkData.filter(Boolean) as RepoData[]));
@@ -567,7 +579,8 @@ async function getAllRepos(
 
 async function processRepo(
   repo: GithubRepo,
-  packageJsonLocations: PackageJsonLocation[]
+  packageJsonLocations: PackageJsonLocation[],
+  role: 'owner' | 'contributor' = 'owner'
 ): Promise<GithubProjectData | undefined> {
   if (!repoFilter(repo)) {
     return;
@@ -600,6 +613,7 @@ async function processRepo(
     type: 'github',
     data: repo,
     repo: repo.name,
+    role,
     deployment,
     description: repo.description,
     url: repo.html_url,


### PR DESCRIPTION
## Summary
- Adds an optional `role: 'owner' | 'contributor'` to GitHub project data so the projects page can surface major open-source contributions (seeded with `nrwl/nx`) alongside owned projects in the same relevance-sorted list.
- Contributor projects render the full `owner/name` title plus a "Contributor" pill badge, making it unambiguous that they're not being claimed as authored work.
- Anchor ids for contributor projects use `owner-name` to avoid collisions with future owned repos of the same short name; existing `#repo-name` deep links for owned projects are unchanged.

## Test plan
- [ ] Delete `tmp/github-projects-cache.json` to force a fresh fetch
- [ ] Run the dev server and load `/projects`
- [ ] Confirm `nrwl/nx` appears in the list with a "Contributor" badge and title `nrwl/nx`
- [ ] Confirm owned projects still render with their short name and no badge
- [ ] Confirm the badge wraps to a second line on narrow viewports rather than forcing the title to truncate