### PR TITLE
feat(qr-generator): decode pasted QR code images into the text input

### DIFF
--- a/apps/qr-generator/components/AppHeader.tsx
+++ b/apps/qr-generator/components/AppHeader.tsx
@@ -11,7 +11,9 @@ export function AppHeader({ onSettingsToggle, settingsOpen }: AppHeaderProps) {
         <h1 className="text-2xl font-semibold text-gray-900 mb-1">
           QR Generator
         </h1>
-        <p className="text-gray-500 text-sm">Generate QR codes instantly</p>
+        <p className="text-gray-500 text-sm">
+          Generate, decode, and verify QR codes instantly
+        </p>
       </div>
       <div className="flex-1 flex justify-end">
         <button

--- a/apps/qr-generator/components/QRInput.tsx
+++ b/apps/qr-generator/components/QRInput.tsx
@@ -2,9 +2,29 @@ interface QRInputProps {
   value: string
   onChange: (value: string) => void
   onKeyDown: (e: React.KeyboardEvent) => void
+  onImagePaste?: (file: File) => void
 }
 
-export function QRInput({ value, onChange, onKeyDown }: QRInputProps) {
+function extractPastedImage(clipboardData: DataTransfer): File | null {
+  for (const item of clipboardData.items) {
+    if (item.kind === 'file' && item.type.startsWith('image/')) {
+      const file = item.getAsFile()
+      if (file) return file
+    }
+  }
+  return null
+}
+
+export function QRInput({ value, onChange, onKeyDown, onImagePaste }: QRInputProps) {
+  const handlePaste = (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!onImagePaste) return
+    const image = extractPastedImage(e.clipboardData)
+    if (image) {
+      e.preventDefault()
+      onImagePaste(image)
+    }
+  }
+
   return (
     <div className="mb-6">
       <div className="relative">
@@ -13,7 +33,8 @@ export function QRInput({ value, onChange, onKeyDown }: QRInputProps) {
           value={value}
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={onKeyDown}
-          placeholder="Enter text, URL, or any content..."
+          onPaste={handlePaste}
+          placeholder="Enter text, URL, or paste a QR code image..."
           className="w-full px-4 py-4 bg-white border border-gray-200 rounded-2xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none transition-all duration-200 text-gray-900 placeholder-gray-400"
           style={{ fontFeatureSettings: 'normal' }}
           rows={3}

--- a/apps/qr-generator/components/QRInput.tsx
+++ b/apps/qr-generator/components/QRInput.tsx
@@ -34,7 +34,7 @@ export function QRInput({ value, onChange, onKeyDown, onImagePaste }: QRInputPro
           onChange={(e) => onChange(e.target.value)}
           onKeyDown={onKeyDown}
           onPaste={handlePaste}
-          placeholder="Enter text, URL, or paste a QR code image..."
+          placeholder="Enter text or a URL — or paste a QR code image to decode it"
           className="w-full px-4 py-4 bg-white border border-gray-200 rounded-2xl focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none transition-all duration-200 text-gray-900 placeholder-gray-400"
           style={{ fontFeatureSettings: 'normal' }}
           rows={3}

--- a/apps/qr-generator/pages/+Page.tsx
+++ b/apps/qr-generator/pages/+Page.tsx
@@ -21,6 +21,7 @@ import {
 } from '../src/image-processing';
 import {
   validateQRCode,
+  decodeQRFromImageBlob,
   type ValidationResult,
 } from '../src/qr-validation';
 
@@ -150,6 +151,19 @@ export default function Page() {
     scheduleGenerate(value, imageSettings, qrSettings);
   };
 
+  const handleImagePaste = async (file: File) => {
+    const decoded = await decodeQRFromImageBlob(file);
+    if (decoded === null) {
+      alert('No QR code detected in the pasted image.');
+      return;
+    }
+    setText(decoded);
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+    generateQRCode(decoded, imageSettings, qrSettings);
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === 'Enter' && !e.shiftKey) {
       e.preventDefault();
@@ -157,16 +171,6 @@ export default function Page() {
         clearTimeout(debounceRef.current);
       }
       generateQRCode(text, imageSettings, qrSettings);
-    }
-    if (e.key === 'v' && e.ctrlKey) {
-      e.preventDefault();
-      navigator.clipboard.readText().then((clipboardText) => {
-        setText(clipboardText);
-        if (debounceRef.current) {
-          clearTimeout(debounceRef.current);
-        }
-        generateQRCode(clipboardText, imageSettings, qrSettings);
-      });
     }
   };
 
@@ -238,6 +242,7 @@ export default function Page() {
       value={text}
       onChange={handleInputChange}
       onKeyDown={handleKeyDown}
+      onImagePaste={handleImagePaste}
     />
   );
 

--- a/apps/qr-generator/src/qr-validation.ts
+++ b/apps/qr-generator/src/qr-validation.ts
@@ -6,6 +6,18 @@ export interface ValidationResult {
   expected: string;
 }
 
+function decodeFromImageElement(img: HTMLImageElement): string | null {
+  const canvas = document.createElement('canvas');
+  canvas.width = img.naturalWidth;
+  canvas.height = img.naturalHeight;
+  const ctx = canvas.getContext('2d')!;
+  ctx.drawImage(img, 0, 0);
+
+  const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const result = jsQR(imageData.data, canvas.width, canvas.height);
+  return result ? result.data : null;
+}
+
 /**
  * Decodes a QR code from a data URL and validates its content matches the expected text.
  */
@@ -16,21 +28,13 @@ export function validateQRCode(
   return new Promise((resolve) => {
     const img = new Image();
     img.onload = () => {
-      const canvas = document.createElement('canvas');
-      canvas.width = img.naturalWidth;
-      canvas.height = img.naturalHeight;
-      const ctx = canvas.getContext('2d')!;
-      ctx.drawImage(img, 0, 0);
-
-      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
-      const result = jsQR(imageData.data, canvas.width, canvas.height);
-
-      if (!result) {
+      const decoded = decodeFromImageElement(img);
+      if (decoded === null) {
         resolve({ valid: false, decoded: null, expected: expectedText });
       } else {
         resolve({
-          valid: result.data === expectedText,
-          decoded: result.data,
+          valid: decoded === expectedText,
+          decoded,
           expected: expectedText,
         });
       }
@@ -39,5 +43,29 @@ export function validateQRCode(
       resolve({ valid: false, decoded: null, expected: expectedText });
     };
     img.src = dataUrl;
+  });
+}
+
+/**
+ * Attempts to decode QR content from an image Blob/File.
+ * Returns the decoded string, or null if no QR code is detected.
+ */
+export function decodeQRFromImageBlob(blob: Blob): Promise<string | null> {
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = () => {
+      URL.revokeObjectURL(url);
+      try {
+        resolve(decodeFromImageElement(img));
+      } catch {
+        resolve(null);
+      }
+    };
+    img.onerror = () => {
+      URL.revokeObjectURL(url);
+      resolve(null);
+    };
+    img.src = url;
   });
 }


### PR DESCRIPTION
## Summary
- Paste an image containing a QR code into the text input; it is decoded via `jsQR` and the result populates the textarea, regenerating the preview.
- New `decodeQRFromImageBlob` helper in `src/qr-validation.ts` (shares a `decodeFromImageElement` with existing validation).
- `QRInput` gains an `onImagePaste` prop; its `onPaste` handler extracts image files from the clipboard and forwards them.
- Removed the redundant `Ctrl+V` `keydown` override in `+Page.tsx` that was `preventDefault`ing the native paste event and blocking the new image paste path.

## Test plan
- [ ] Copy a QR code image (e.g. screenshot) and paste into the text box — textarea fills with decoded content and QR preview regenerates.
- [ ] Paste an image without a QR code — user gets an alert and text is unchanged.
- [ ] Paste plain text — textarea receives it normally and regenerates (debounced).
- [ ] `Ctrl+V` with text still works; `Enter` still triggers immediate generation.

https://claude.ai/code/session_01ABLorQUs58Ctzqz3wm4uAb