### PR TITLE
fix(related-content): build apps first, or /tools and /projects lose their Launch links (#545)

### DIFF
--- a/apps/craigory-dev/pages/presentations/index/+Page.tsx
+++ b/apps/craigory-dev/pages/presentations/index/+Page.tsx
@@ -56,8 +56,8 @@ export function Page() {
               key={p.title + p.presentedAt + 'DESCRIPTION'}
               className="description"
             >
-              {p.description.split('\n').map((line) => (
-                <p key={line}>{line}</p>
+              {p.description.split('\n').map((line, lineIdx) => (
+                <p key={lineIdx}>{line}</p>
               ))}
               <div className="links">
                 {p.mdUrl || p.htmlUrl ? (

--- a/apps/craigory-dev/pages/projects/language-logos.tsx
+++ b/apps/craigory-dev/pages/projects/language-logos.tsx
@@ -10,6 +10,10 @@ import {
 } from 'react-icons/si';
 import { BsTerminalFill } from 'react-icons/bs';
 
+// This runs in render, once per language per project card, on both the SSR and
+// hydration passes. Without deduping, one unmapped language floods the console.
+const reportedMissingLogos = new Set<string>();
+
 export function getLanguageLogo(language: string) {
   switch (language) {
     case 'TypeScript':
@@ -139,7 +143,10 @@ export function getLanguageLogo(language: string) {
       );
 
     default:
-      console.log(`No icon for language: ${language}`);
+      if (import.meta.env.DEV && !reportedMissingLogos.has(language)) {
+        reportedMissingLogos.add(language);
+        console.log(`No icon for language: ${language}`);
+      }
       return null;
   }
 }

--- a/apps/craigory-dev/src/shared-components/content-marker.tsx
+++ b/apps/craigory-dev/src/shared-components/content-marker.tsx
@@ -1,4 +1,4 @@
-import { toast } from './toaster';
+import { toast } from './toast';
 
 export function ContentMarker() {
   return (

--- a/apps/craigory-dev/src/shared-components/spotlight-context.ts
+++ b/apps/craigory-dev/src/shared-components/spotlight-context.ts
@@ -1,0 +1,20 @@
+import { createContext, useContext } from 'react';
+
+/**
+ * Split out from spotlight-search.tsx so that file exports nothing but
+ * components. A module mixing component and non-component exports can't be a
+ * React Fast Refresh boundary, so editing it invalidates every importer up to
+ * +Layout — which remounts the whole shell on the next navigation.
+ */
+
+export interface SpotlightContextValue {
+  open: () => void;
+}
+
+export const SpotlightContext = createContext<SpotlightContextValue>({
+  open: () => undefined,
+});
+
+export function useSpotlight(): SpotlightContextValue {
+  return useContext(SpotlightContext);
+}

--- a/apps/craigory-dev/src/shared-components/spotlight-search.tsx
+++ b/apps/craigory-dev/src/shared-components/spotlight-search.tsx
@@ -1,13 +1,12 @@
 import React, {
-  createContext,
   useCallback,
-  useContext,
   useEffect,
   useMemo,
   useRef,
   useState,
 } from 'react';
 import styles from './spotlight-search.module.scss';
+import { SpotlightContext, useSpotlight } from './spotlight-context';
 
 /**
  * Spotlight-style site search over the Pagefind index built by
@@ -138,20 +137,6 @@ function toEntries(document_: PagefindDocument): Entry[] {
   }
 
   return entries;
-}
-
-// ---------------------------------------------------------------- context
-
-interface SpotlightContextValue {
-  open: () => void;
-}
-
-const SpotlightContext = createContext<SpotlightContextValue>({
-  open: () => undefined,
-});
-
-export function useSpotlight(): SpotlightContextValue {
-  return useContext(SpotlightContext);
 }
 
 export function SpotlightProvider({ children }: { children: React.ReactNode }) {

--- a/apps/craigory-dev/src/shared-components/toast.ts
+++ b/apps/craigory-dev/src/shared-components/toast.ts
@@ -1,0 +1,33 @@
+/**
+ * The toast API, split out from <Toaster> so that toaster.tsx exports nothing
+ * but a component. A module mixing component and non-component exports can't
+ * be a React Fast Refresh boundary, so editing it invalidates every importer
+ * up to +Layout — which remounts the whole shell on the next navigation.
+ */
+
+declare global {
+  interface GlobalEventHandlersEventMap {
+    toast: CustomEvent<ToastOptions>;
+  }
+}
+
+export type ToastContent = string | JSX.Element;
+
+export type ToastOptions = {
+  content: ToastContent;
+  style?: 'success' | 'error' | 'info';
+  duration?: number;
+  ephemeral?: boolean;
+};
+
+export type Toast = ToastOptions & {
+  id: string;
+};
+
+export function toast(options: ToastOptions) {
+  window.dispatchEvent(
+    new CustomEvent('toast', {
+      detail: options,
+    })
+  );
+}

--- a/apps/craigory-dev/src/shared-components/toaster.tsx
+++ b/apps/craigory-dev/src/shared-components/toaster.tsx
@@ -2,32 +2,7 @@ import { useEffect, useState } from 'react';
 
 import { IoClose } from 'react-icons/io5';
 
-declare global {
-  interface GlobalEventHandlersEventMap {
-    toast: CustomEvent<ToastOptions>;
-  }
-}
-
-export type ToastContent = string | JSX.Element;
-
-export type ToastOptions = {
-  content: ToastContent;
-  style?: 'success' | 'error' | 'info';
-  duration?: number;
-  ephemeral?: boolean;
-};
-
-export type Toast = ToastOptions & {
-  id: string;
-};
-
-export function toast(options: ToastOptions) {
-  window.dispatchEvent(
-    new CustomEvent('toast', {
-      detail: options,
-    })
-  );
-}
+import type { Toast, ToastOptions } from './toast';
 
 export function Toaster() {
   const [toasts, setToasts] = useState<Toast[]>([]);

--- a/docs/plans/2026-07-28-site-search-and-related-content.md
+++ b/docs/plans/2026-07-28-site-search-and-related-content.md
@@ -184,6 +184,47 @@ Note the caches have **no TTL**: project data refreshes only when `tmp/` is
 cleared. CI checks out fresh every run so production is current, but a long-lived
 local checkout can be serving very old project data.
 
+#### The regression this caused, and the real fix
+
+Adding a second caller broke deployment links on `/tools` and `/projects`.
+
+`getLocalProjects()` derives `deployment` from whether the project's build output
+exists on disk (`projects.ts:1186`), and that verdict was being **written into the
+cache**. Previously the only caller was `onCreateGlobalContext`, which runs inside
+`vike build` — after every `^build` dependency, so `dist/apps/*` always existed.
+`related-content:build` runs *during* the `^build` phase, in parallel with the
+sibling app builds, and observed in a real build log running **before**
+`alt-codes:build`. On a fresh CI checkout (`apps/*/dist` is gitignored) it saw no
+build output, cached `deployment: undefined`, and — since the cache never
+expires — every later build rendered a linkless page.
+
+**The fix is the missing dependency edge.** This step reads project state that the
+app builds produce, so it depends on those builds — that relationship was simply
+never declared:
+
+```json
+"dependsOn": [{ "projects": ["apps/*", "!craigory-dev"], "target": "build" }]
+```
+
+`craigory-dev` is excluded because it depends on *this* target; including it would
+be a cycle. The glob is negated rather than spelled out as a list so a new app is
+covered automatically — and note the project name is `pr-digest-viewer` even
+though the directory is `apps/pr-digest`, which a hardcoded list would get wrong.
+
+Fixing the ordering is better than making the consumer defensive about one field.
+It is the honest description of the dependency, and it holds for *any* build-state
+-derived value the loader caches, not just `deployment`.
+
+Verified on a real build: `json-viewer:build` at log line 99 and `alt-codes:build`
+at 420, with `related-content:build` at **8835** — after all of them. The
+regenerated cache carries 8/12 deployments (the 4 without are packages, which
+genuinely have none), `/tools` links all five tools, and `/projects` renders 36
+Live URL entries.
+
+Remaining sharp edge: the ordering only applies through Nx. Running
+`bun run libs/related-content/build/main.ts` by hand before the apps are built will
+still write a cache with no deployments. Clear `tmp/*.json` if that happens.
+
 ### Storage and scoring
 
 `node_modules/.cache/related-content/embeddings.db` (gitignored by virtue of

--- a/libs/related-content/project.json
+++ b/libs/related-content/project.json
@@ -14,6 +14,21 @@
         "so nothing throws and file paths get embedded as blog prose."
       ],
       "command": "bun run libs/related-content/build/main.ts",
+      "// dependsOn": [
+        "Every app except craigory-dev must be built first.",
+        "This step calls the site's own loadAllProjects(), which decides whether",
+        "a project has a deployment URL by checking that its build output exists",
+        "on disk — and persists that verdict to tmp/local-projects-cache.json,",
+        "which never expires. Running before the apps are built therefore caches",
+        "'no deployment' for all of them and leaves /tools and /projects without",
+        "links until someone clears tmp/ by hand.",
+        "craigory-dev is excluded because it depends on THIS target; including it",
+        "would be a cycle. The glob is negated rather than a hardcoded list so a",
+        "new app is covered automatically."
+      ],
+      "dependsOn": [
+        { "projects": ["apps/*", "!craigory-dev"], "target": "build" }
+      ],
       "outputs": ["{projectRoot}/src/generated/related.json"],
       "// cache": [
         "Deliberately uncached. The step's own sqlite DB is already a cache, and",


### PR DESCRIPTION
Cherry-picks `b99aff9d5` off the `tiki-explore` branch, where it was stranded behind ~137 commits of unrelated bar3d work. Task #545.

## Why this matters

The **Launch links on `/tools` and `/projects` disappear**, and stay gone.

`loadAllProjects()` decides whether a project has a deployment URL by checking that its build output exists on disk, then persists that verdict to `tmp/local-projects-cache.json` — **which never expires**.

`libs/related-content`'s build step calls `loadAllProjects()`. Run *before* the sibling apps are built, it caches "no deployment" for every one of them, and the Launch links stay broken until someone deletes `tmp/` by hand. Nothing surfaces an error; the buttons are just silently absent.

The fix declares the ordering that was previously only implicit:

```jsonc
"dependsOn": [
  { "projects": ["apps/*", "!craigory-dev"], "target": "build" }
]
```

Two details worth keeping:

- **The glob is negated rather than a hardcoded list**, so a newly-added app is covered automatically. This already paid off — `tree-generator` (the asciitree app, #45) landed on `main` after this commit was authored, and the task graph picks it up with no edit.
- **`craigory-dev` is excluded** because it depends on *this* target; including it would be a cycle.

## Also in this commit

Search follow-ups that belong on `main` regardless — none of it bar3d-related:

- spotlight context + toast helpers extracted into their own modules
- spotlight / toaster / content-marker polish; presentations page wiring
- missing-language-logo `console.log` deduped — it was firing once per language *per card per render pass*, on both SSR and hydration
- the search/related-content plan doc updated to match what landed

The commit is taken whole rather than splitting the one `project.json` hunk out, since the rest is coherent follow-up work to the search feature already on `main`.

## Verification

| Check | Result |
| --- | --- |
| `nx run-many -t lint -p craigory-dev related-content` | ✓ 0 errors (17 pre-existing warnings, none in touched files) |
| `nx run-many -t test -p craigory-dev related-content` | ✓ pass |
| Task graph for `related-content:build` | ✓ 9 app builds as prerequisites, `craigory-dev:build` correctly absent, `tree-generator:build` auto-included |
| `typecheck` | n/a — neither project defines the target |
| `nx build craigory-dev` | ⚠️ not verified locally — see below |

The full site build couldn't be exercised locally: `loadAllProjects()` calls GitHub's `/search/code` endpoint, which always requires authentication, and no PAT is reachable from the environment this was prepared in. It fails identically on unmodified `origin/main`, and the three files in the failing stack (`src/data/projects.ts`, `pages/projects/+Page.tsx`, `pages/projects/+data.ts`) are byte-identical to `origin/main` — so it is not a regression from this change. **CI's build is the real gate here**, and it's the exact thing this PR fixes, so it's worth a look at the CI logs confirming `related-content:build` now runs after the app builds.

## Scope check

`git log -S"local-projects-cache" main..tiki-explore` returns only this commit — it is the sole change on that branch touching this behaviour.
