### PR TITLE
fix(justlisten): stop bundling the shared vike auto-importer

### DIFF
--- a/apps/justlisten/vite.config.ts
+++ b/apps/justlisten/vite.config.ts
@@ -2,7 +2,49 @@ import { cloudflare } from '@cloudflare/vite-plugin';
 import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import vike from 'vike/plugin';
-import { defineConfig } from 'vite';
+import { defineConfig, type Plugin } from 'vite';
+
+// vike's server runtime imports `@brillout/vite-plugin-server-entry`'s
+// `autoImporter.js`: ONE file inside node_modules that every vike app in this
+// repo rewrites while it builds, ending with an `import()` of that app's own
+// `dist/server/entry.mjs`. The prerendered apps keep vike external, so they
+// never look inside it — but the Cloudflare plugin bundles vike into the
+// Worker, so rollup parses whatever some *other* app's parallel `nx run-many`
+// build last wrote there and fails on a path that doesn't exist. justlisten
+// doesn't need the file (the entry is bundled via `vike:server-entry`), so
+// bundle its pristine "unset" form instead of the shared mailbox.
+function stubServerEntryAutoImporter(): Plugin {
+  const stubId = '\0justlisten:server-entry-auto-importer';
+  let stubbed = false;
+  return {
+    name: 'justlisten:stub-server-entry-auto-importer',
+    enforce: 'pre',
+    resolveId(source, importer) {
+      if (
+        source.endsWith('/autoImporter.js') &&
+        importer?.includes('/@brillout/vite-plugin-server-entry/')
+      ) {
+        stubbed = true;
+        return stubId;
+      }
+    },
+    load(id) {
+      if (id === stubId) return "export const status = 'UNSET';";
+    },
+    // The match above is against a private path, so a plugin upgrade could
+    // rename it out from under us. Fail here rather than silently going back
+    // to bundling the shared file (which only breaks when a sibling build
+    // happens to be mid-flight).
+    buildEnd(error) {
+      if (error || this.environment.name !== 'ssr' || stubbed) return;
+      throw new Error(
+        'stubServerEntryAutoImporter: the SSR build never imported ' +
+          "@brillout/vite-plugin-server-entry's autoImporter.js — the path " +
+          'it matches has probably changed; update the plugin or drop it.'
+      );
+    },
+  };
+}
 
 export default defineConfig({
   plugins: [
@@ -13,7 +55,11 @@ export default defineConfig({
     react(),
     tailwindcss(),
     vike(),
+    stubServerEntryAutoImporter(),
   ],
+  // Stop writing the shared file too (see stubServerEntryAutoImporter above),
+  // so justlisten can't be the app that breaks a sibling's parallel build.
+  vitePluginServerEntry: { disableAutoImport: true },
   environments: {
     ssr: {
       optimizeDeps: {


### PR DESCRIPTION
## Current Behavior

`nx run-many -t build` intermittently fails justlisten's SSR build:

```
Could not resolve "../../../../../../../../../apps/qr-generator/dist/server/entry.mjs" from ".../@brillout/vite-plugin-server-entry/dist/esm/runtime/autoImporter.js"
```

`@brillout/vite-plugin-server-entry` rewrites one file in `node_modules` during every vike app's build, ending with an `import()` of that app's own `dist/server/entry.mjs`. justlisten is the only app that bundles vike into its output (the Cloudflare plugin can't leave it external), so rollup parses whatever a sibling build last wrote there. The path is dangling because the sibling writes it in `generateBundle`, before its `entry.mjs` exists.

## Expected Behavior

justlisten's build doesn't depend on what the other apps are doing. We resolve that import to a `status = 'UNSET'` stub and stop writing the file from justlisten too. A plugin bump that renames the file fails the build loudly instead of bringing the flake back.
