### PR TITLE
Add "BS CVEs and Maintainer Burnout", plus the blog components it needed

### DIFF
--- a/apps/craigory-dev/pages/blog/view/+Page.tsx
+++ b/apps/craigory-dev/pages/blog/view/+Page.tsx
@@ -1,9 +1,13 @@
 import {
   slugMap,
+  Callout,
+  Citations,
+  CitationsProvider,
   Cite,
   CodeWrapper,
   LinkToPost,
   PostContext,
+  Quote,
   Tab,
   Tabs,
   TikiTable,
@@ -49,26 +53,26 @@ export function Page() {
 
   return (
     <>
-      {returnLink ? (
-        <div className="return-link-top">
-          <Link href={returnLink}>← Return to previous page</Link>
-        </div>
-      ) : null}
       <PostContext.Provider value={postData}>
         <div className={`blog-post-theme ${getPostThemeClass(postData)}`}>
           <BlogPostEnhanced>
+            <CitationsProvider>
             {postData.mdx({
               components: {
                 h1: BlogH1,
                 pre: CodeWrapper,
                 Anchor: ContentMarker,
+                Callout,
+                Citations,
                 Cite,
                 LinkToPost,
+                Quote,
                 Tab,
                 Tabs,
                 TikiTable,
               },
             })}
+            </CitationsProvider>
           </BlogPostEnhanced>
         </div>
         {/* Outside the themed wrapper so a tiki post's palette does not bleed

--- a/apps/craigory-dev/pages/blog/view/view.page.scss
+++ b/apps/craigory-dev/pages/blog/view/view.page.scss
@@ -762,21 +762,7 @@ div {
 }
 
 // Return link styles
-.return-link-top {
-  a {
-    color: #667eea;
-    text-decoration: none;
-    font-weight: 500;
-    transition: color 0.2s ease;
-
-    &:hover {
-      color: #764ba2;
-    }
-  }
-}
-
 // Tiki theme return links
-.blog-post-theme.theme-tiki .return-link-top a,
 .blog-post-theme.theme-tiki .return-link-bottom a {
   color: #d84315 !important;
 

--- a/apps/craigory-dev/plugins.ts
+++ b/apps/craigory-dev/plugins.ts
@@ -7,7 +7,6 @@ import rehypeMdxCodeProps from 'rehype-mdx-code-props';
 import rehypeSlug from 'rehype-slug';
 import remarkRehype from 'remark-rehype';
 import remarkSmartypants from 'remark-smartypants';
-import remarkToc from 'remark-toc';
 
 const rehypeAutolinkHeadingsOptions: RehypeAutolinkOptions = {
   behavior: 'append',
@@ -23,21 +22,12 @@ const rehypeAutolinkHeadingsOptions: RehypeAutolinkOptions = {
     className: 'heading-link',
   },
   test: (el) => {
-    if (el.type === 'element') {
-      if (el.tagName === 'h1') return false;
-      if (
-        el.tagName === 'h2' &&
-        el.children?.find(
-          (el) => el.type === 'text' && el.value === 'Table of Contents'
-        )
-      )
-        return false;
-    }
+    if (el.type === 'element' && el.tagName === 'h1') return false;
     return true;
   },
 };
 
-export const REMARK_PLUGINS = [remarkToc, remarkSmartypants, remarkRehype];
+export const REMARK_PLUGINS = [remarkSmartypants, remarkRehype];
 
 export const REHYPE_PLUGINS = [
   rehypeSlug,

--- a/apps/craigory-dev/src/utils/reading-time.ts
+++ b/apps/craigory-dev/src/utils/reading-time.ts
@@ -1,4 +1,4 @@
-import { BlogPost } from '@new-personal-monorepo/blog-posts';
+import { BlogPost, CitationsProvider } from '@new-personal-monorepo/blog-posts';
 import { renderToString } from 'react-dom/server';
 import { createElement } from 'react';
 
@@ -11,12 +11,17 @@ export function calculateReadingTimeFromPost(post: BlogPost): number {
       TikiTable: ({ children }: { children?: any }) => children || '', // Pass through table content
       Tabs: ({ children }: { children?: any }) => children || '', // Pass through tabbed content
       Tab: ({ children }: { children?: any }) => children || '', // Pass through tab panel content
+      Callout: ({ children }: { children?: any }) => children || '', // Pass through callout body
       Cite: ({ children }: { children?: any }) => children || '', // Pass through citation body
+      Quote: ({ children }: { children?: any }) => children || '', // Pass through quoted text
+      Citations: () => null, // Source list repeats bodies already counted via Cite
       pre: ({ children }: { children?: any }) => children || '', // Keep code content for word count
     };
     
     // Try to render the MDX to HTML and extract text content
-    const htmlString = renderToString(createElement(post.mdx, { components: stubComponents }));
+    const htmlString = renderToString(
+      createElement(CitationsProvider, null, createElement(post.mdx, { components: stubComponents }))
+    );
     const textContent = extractTextFromHTML(htmlString);
     const wordCount = textContent.split(/\s+/).filter(word => word.length > 0).length;
     

--- a/docs/blog-writing-guide.md
+++ b/docs/blog-writing-guide.md
@@ -108,11 +108,61 @@ export const npmDocs = (
   </>
 );
 
-The setting is read from the project's `.npmrc`.<Cite n={1} href="https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age">{npmDocs}</Cite>
+The setting is read from the project's `.npmrc`.<Cite href="https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age">{npmDocs}</Cite>
 ```
 
-Number `n` sequentially through the post. Attach the `<Cite>` directly to the
-end of the claim, with no space before it.
+Attach the `<Cite>` directly to the end of the claim, with no space before it.
+
+**Do not number citations by hand.** The marker number comes from the order
+sources are first cited, keyed by `href`. Citing the same URL again reuses its
+number instead of adding a second entry, so a source quoted twice stays one
+footnote.
+
+End the post with `<Citations />`, which renders every source cited above it as
+a numbered list under a `Sources` heading. It takes an optional `title`.
+
+### Quotes
+
+For a quotation whose source should be visible on the quote itself, rather than
+trailing off the sentence that introduced it:
+
+```mdx
+<Quote
+  href="https://sethmlarson.dev/slop-security-reports"
+  by="Seth Larson"
+  work="Please stop submitting AI slop security reports"
+  cite={larsonSlop}
+>
+
+even if this is not their intent, the outcome is maintainers that are burnt out
+and more averse to legitimate security work.
+
+</Quote>
+```
+
+Renders a `figure`/`blockquote`/`figcaption`, with the attribution and citation
+marker below the quote. `cite` is the same fragment a `<Cite>` would take, and
+feeds both the marker's popover and the source list. Leave blank lines around
+the quoted text so it parses as Markdown.
+
+Plain `>` blockquotes still work, but prefer `<Quote>` whenever the words came
+from an identifiable source.
+
+### Callouts
+
+An editorial aside — a scope note, disclaimer, or correction — set apart from
+the body text:
+
+```mdx
+<Callout title="About the examples">
+
+Nothing below says Nx is unsafe.
+
+</Callout>
+```
+
+`title` is optional. Deliberately styled unlike `blockquote`, so a disclaimer
+does not read as something a source said.
 
 ### Tabs
 
@@ -151,11 +201,14 @@ takes no props and belongs at the end of a review.
 
 1. `#` title
 2. A short framing paragraph — the problem, or the misconception being corrected
-3. `## Table of Contents` for longer posts
-4. Body sections, working from concept to implementation
-5. `### Case Study: ...` for worked examples
-6. `## Some Caveats` — where the approach breaks down
-7. `## Conclusion`
+3. Body sections, working from concept to implementation
+4. `### Case Study: ...` for worked examples
+5. `## Some Caveats` — where the approach breaks down
+6. `## Conclusion`
+
+Do not add a `## Table of Contents` heading. The post page builds its own
+contents list in the sidebar from the rendered `h2`/`h3`/`h4` headings, so an
+in-content one duplicates it and shows up as an entry inside it.
 
 ### Tiki reviews
 

--- a/libs/blog-posts/.vale/styles/config/vocabularies/Blog/accept.txt
+++ b/libs/blog-posts/.vale/styles/config/vocabularies/Blog/accept.txt
@@ -1,4 +1,7 @@
 # Tooling and ecosystem
+unix
+chmods?
+bundlers?
 Nx
 Nrwl
 pnpm
@@ -89,6 +92,9 @@ mai
 tai
 
 # People and proper nouns
+Stenberg
+CPython
+Abramov
 Collina
 Matteo
 Ricci
@@ -96,3 +102,18 @@ Tollner
 Uber
 maintainer
 maintainers
+
+# Security and supply chain
+CVEs?
+triages
+xz
+minimatch
+glob-parent
+braceExpand
+[Rr]eachability
+untrusted
+globbing
+Snyk
+VEX
+CSAF
+CVSS

--- a/libs/blog-posts/src/index.ts
+++ b/libs/blog-posts/src/index.ts
@@ -1,8 +1,11 @@
 export { blogPosts, pages, slugMap } from './lib/posts';
+export * from './lib/components/callout';
+export * from './lib/components/citations';
 export * from './lib/components/cite';
 export * from './lib/components/code-wrapper';
 export * from './lib/components/link-to-post';
 export * from './lib/components/post-context';
+export * from './lib/components/quote';
 export * from './lib/components/tabs';
 export * from './lib/components/tiki-table';
 export * from './lib/blog-post';

--- a/libs/blog-posts/src/lib/components/callout.module.scss
+++ b/libs/blog-posts/src/lib/components/callout.module.scss
@@ -1,0 +1,35 @@
+// The class is doubled in the compiled output (`.callout.callout`) to raise
+// specificity to 0,2,0. `.blog-content p` in view.page.scss is 0,1,1 and sets
+// a 1.75rem paragraph margin meant for body copy; a single module class ties
+// with it and would win or lose on stylesheet order.
+.callout.callout {
+  margin: 2rem 0;
+  padding: 1.25rem 1.5rem;
+  border: 1px solid rgba(76, 81, 191, 0.28);
+  border-radius: 10px;
+  background: rgba(76, 81, 191, 0.045);
+
+  p {
+    margin: 0 0 0.875rem;
+    font-style: normal;
+    line-height: 1.7;
+    color: #3a3a3a;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.label {
+  // Overrides the shared paragraph colour above, so it needs to sit at the
+  // same doubled specificity.
+  .callout.callout & {
+    margin-bottom: 0.625rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #4c51bf;
+  }
+}

--- a/libs/blog-posts/src/lib/components/callout.tsx
+++ b/libs/blog-posts/src/lib/components/callout.tsx
@@ -1,0 +1,27 @@
+import { ReactNode } from 'react';
+import classes from './callout.module.scss';
+
+export interface CalloutProps {
+  /**
+   * Short label rendered above the body, e.g. "About the examples". Rendered
+   * as plain text rather than a heading so the callout stays out of the
+   * table of contents, which is built from the post's h2/h3 elements.
+   */
+  title?: string;
+  /** Callout body. Markdown inside the tag is parsed as usual. */
+  children?: ReactNode;
+}
+
+/**
+ * An editorial aside — a disclaimer, scope note, or correction — set apart
+ * from the body text. Deliberately unlike `blockquote`, which posts use for
+ * quoting sources: no left rule, no italics.
+ */
+export function Callout({ title, children }: CalloutProps) {
+  return (
+    <aside className={classes['callout']}>
+      {title ? <p className={classes['label']}>{title}</p> : null}
+      {children}
+    </aside>
+  );
+}

--- a/libs/blog-posts/src/lib/components/citations.module.scss
+++ b/libs/blog-posts/src/lib/components/citations.module.scss
@@ -1,0 +1,31 @@
+.citations {
+  margin-top: 3rem;
+}
+
+// Doubled to clear `.blog-content ol` / `.blog-content p` in view.page.scss.
+.list.list {
+  margin-bottom: 0;
+  padding-left: 1.5rem;
+
+  li {
+    margin-bottom: 0.875rem;
+    font-size: 0.9rem;
+    line-height: 1.6;
+    color: #555;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
+
+    // Anchor target when a marker is linked to its entry.
+    &:target {
+      background: rgba(76, 81, 191, 0.08);
+      border-radius: 4px;
+    }
+  }
+
+  a {
+    color: #4c51bf;
+    word-break: break-word;
+  }
+}

--- a/libs/blog-posts/src/lib/components/citations.tsx
+++ b/libs/blog-posts/src/lib/components/citations.tsx
@@ -1,0 +1,145 @@
+import {
+  createContext,
+  ReactNode,
+  useContext,
+  useRef,
+  useSyncExternalStore,
+} from 'react';
+import classes from './citations.module.scss';
+
+export interface CitedSource {
+  /** 1-based position, assigned in first-cited order. */
+  n: number;
+  href: string;
+  body?: ReactNode;
+}
+
+/**
+ * Assigns citation numbers in the order sources are first cited, and keeps the
+ * list for `<Citations />` to render.
+ *
+ * Registration happens during render rather than in an effect, because the blog
+ * is server-rendered and effects never run there. That is safe here because
+ * `register` is keyed by href and idempotent: re-renders and StrictMode's
+ * double render return the number already assigned instead of appending.
+ */
+class CitationRegistry {
+  private order: string[] = [];
+  private bodies = new Map<string, ReactNode>();
+  private listeners = new Set<() => void>();
+  private snapshot: CitedSource[] = [];
+  private notifyQueued = false;
+
+  register = (href: string, body?: ReactNode): number => {
+    const existing = this.order.indexOf(href);
+    if (existing === -1) {
+      this.order.push(href);
+      this.bodies.set(href, body ?? null);
+      this.rebuild();
+      return this.order.length;
+    }
+    // A repeat citation may carry the body that the first one omitted.
+    if (body != null && this.bodies.get(href) == null) {
+      this.bodies.set(href, body);
+      this.rebuild();
+    }
+    return existing + 1;
+  };
+
+  subscribe = (listener: () => void): (() => void) => {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  };
+
+  getSnapshot = (): CitedSource[] => this.snapshot;
+
+  private rebuild() {
+    this.snapshot = this.order.map((href, i) => ({
+      n: i + 1,
+      href,
+      body: this.bodies.get(href) ?? undefined,
+    }));
+    // Notifying synchronously would be a state update during another
+    // component's render pass, so defer it past the end of this one.
+    if (this.notifyQueued) return;
+    this.notifyQueued = true;
+    queueMicrotask(() => {
+      this.notifyQueued = false;
+      this.listeners.forEach((listener) => listener());
+    });
+  }
+}
+
+const CitationsContext = createContext<CitationRegistry | null>(null);
+
+export function CitationsProvider({ children }: { children?: ReactNode }) {
+  // Lazily constructed so each post page gets its own numbering.
+  const ref = useRef<CitationRegistry | null>(null);
+  if (!ref.current) {
+    ref.current = new CitationRegistry();
+  }
+  return (
+    <CitationsContext.Provider value={ref.current}>
+      {children}
+    </CitationsContext.Provider>
+  );
+}
+
+function useRegistry(): CitationRegistry {
+  const registry = useContext(CitationsContext);
+  if (!registry) {
+    throw new Error(
+      'Citation components must be rendered inside <CitationsProvider>.'
+    );
+  }
+  return registry;
+}
+
+/** Returns this source's citation number, assigning one on first use. */
+export function useCitationPosition(href: string, body?: ReactNode): number {
+  return useRegistry().register(href, body);
+}
+
+/** Every source cited so far, in citation order. */
+export function useCitedSources(): CitedSource[] {
+  const registry = useRegistry();
+  return useSyncExternalStore(
+    registry.subscribe,
+    registry.getSnapshot,
+    registry.getSnapshot
+  );
+}
+
+export interface CitationsProps {
+  /** Heading text. Rendered as an h2, so it joins the sidebar contents list. */
+  title?: string;
+}
+
+/**
+ * The post's source list. Belongs at the end of the MDX: it renders whatever
+ * has been cited above it.
+ */
+export function Citations({ title = 'Sources' }: CitationsProps) {
+  const sources = useCitedSources();
+  if (sources.length === 0) {
+    return null;
+  }
+  return (
+    <section className={classes['citations']}>
+      <h2>{title}</h2>
+      <ol className={classes['list']}>
+        {sources.map((source) => (
+          <li key={source.href} id={`source-${source.n}`}>
+            {source.body ?? (
+              <a href={source.href} target="_blank" rel="noopener noreferrer">
+                {source.href}
+              </a>
+            )}
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/libs/blog-posts/src/lib/components/cite.tsx
+++ b/libs/blog-posts/src/lib/components/cite.tsx
@@ -1,9 +1,8 @@
 import { CSSProperties, ReactNode, useId } from 'react';
+import { useCitationPosition } from './citations';
 import classes from './cite.module.scss';
 
 export interface CiteProps {
-  /** Citation number rendered in the inline marker, e.g. [1] */
-  n: number;
   /** Source URL. The marker is an anchor that opens the URL in a new tab. */
   href: string;
   /**
@@ -13,7 +12,9 @@ export interface CiteProps {
   children?: ReactNode;
 }
 
-export function Cite({ n, href, children }: CiteProps) {
+export function Cite({ href, children }: CiteProps) {
+  // Numbered by first-cited order rather than by hand.
+  const n = useCitationPosition(href, children);
   // CSS dashed-idents only accept [a-zA-Z0-9_-]; useId returns identifiers
   // that include `:` and `«»` characters, so strip them.
   const cleanId = useId().replace(/[^a-zA-Z0-9]/g, '');

--- a/libs/blog-posts/src/lib/components/quote.module.scss
+++ b/libs/blog-posts/src/lib/components/quote.module.scss
@@ -1,0 +1,43 @@
+// The figure owns the visual chrome so the attribution sits inside the same
+// block as the quote. Doubled class beats `.blog-content blockquote` (0,1,1)
+// in view.page.scss, which would otherwise re-apply its standalone styling to
+// the nested blockquote.
+.quote.quote {
+  margin: 2rem 0;
+  background: linear-gradient(to right, #f9f9f9 0%, #ffffff 100%);
+  border-left: 4px solid #667eea;
+
+  blockquote {
+    margin: 0;
+    padding: 1.5rem 1.5rem 0 2rem;
+    background: none;
+    border-left: none;
+  }
+
+  .attribution {
+    padding: 0.75rem 1.5rem 1.25rem 2rem;
+    font-size: 0.875rem;
+    font-style: normal;
+    line-height: 1.5;
+    color: #666;
+
+    a {
+      color: #4c51bf;
+      text-decoration: none;
+      font-weight: 500;
+
+      &:hover,
+      &:focus-visible {
+        text-decoration: underline;
+      }
+    }
+
+    cite {
+      font-style: italic;
+    }
+  }
+
+  .dash {
+    color: #999;
+  }
+}

--- a/libs/blog-posts/src/lib/components/quote.tsx
+++ b/libs/blog-posts/src/lib/components/quote.tsx
@@ -1,0 +1,43 @@
+import { ReactNode } from 'react';
+import { Cite } from './cite';
+import classes from './quote.module.scss';
+
+export interface QuoteProps {
+  /** Source URL. Used for both the attribution link and the citation marker. */
+  href: string;
+  /** Who said it, e.g. "Seth Larson". */
+  by: string;
+  /** The work it appeared in. Rendered inside a semantic <cite>. */
+  work?: string;
+  /** Citation body for the marker's popover, and for the source list. */
+  cite?: ReactNode;
+  /** The quoted text. */
+  children?: ReactNode;
+}
+
+/**
+ * A quotation that carries its own source. Renders the standard
+ * figure/blockquote/figcaption pairing, so the attribution is associated with
+ * the quote rather than trailing off the sentence that introduced it.
+ */
+export function Quote({ href, by, work, cite, children }: QuoteProps) {
+  return (
+    <figure className={classes['quote']}>
+      <blockquote cite={href}>{children}</blockquote>
+      <figcaption className={classes['attribution']}>
+        <span className={classes['dash']} aria-hidden="true">
+          —{' '}
+        </span>
+        <a href={href} target="_blank" rel="noopener noreferrer">
+          {by}
+        </a>
+        {work ? (
+          <>
+            , <cite>{work}</cite>
+          </>
+        ) : null}
+        <Cite href={href}>{cite}</Cite>
+      </figcaption>
+    </figure>
+  );
+}

--- a/libs/blog-posts/src/lib/posts/bs-cves-and-maintainer-burnout/contents.mdx
+++ b/libs/blog-posts/src/lib/posts/bs-cves-and-maintainer-burnout/contents.mdx
@@ -1,0 +1,394 @@
+export const nxGenerateFiles = (
+  <>
+    Nx source,{' '}
+    <a href="https://github.com/nrwl/nx/blob/master/packages/devkit/src/generators/generate-files.ts">
+      <code>packages/devkit/src/generators/generate-files.ts</code>
+    </a>
+    . The only <code>ejs.render</code> call in the repository.
+  </>
+);
+
+export const ejsClosedelimiterCve = (
+  <>
+    GitHub advisory{' '}
+    <a href="https://github.com/advisories/GHSA-j5pp-6f4w-r5r6">
+      GHSA-j5pp-6f4w-r5r6
+    </a>{' '}
+    (CVE-2023-29827), CVSS 9.8. Server-side template injection through the{' '}
+    <code>closeDelimiter</code> option. Still listed as Unreviewed.
+  </>
+);
+
+export const ejsEscapefunctionIssue = (
+  <>
+    EJS issue <a href="https://github.com/mde/ejs/issues/735">#735</a>. The same
+    shape through <code>opts.escapeFunction</code> when <code>opts.client</code>{' '}
+    is set, with the reporter's vector being an option merged in from a query
+    string.
+  </>
+);
+
+export const nxEjsBump = (
+  <>
+    Nx pull request <a href="https://github.com/nrwl/nx/pull/35157">#35157</a>,{' '}
+    <code>fix(core): update and pin ejs to 5.0.1</code>, merged 2 April 2026 and
+    first released in{' '}
+    <a href="https://github.com/nrwl/nx/releases/tag/22.7.0">Nx 22.7.0</a>.
+  </>
+);
+
+export const nxFindMatchingProjects = (
+  <>
+    Nx source,{' '}
+    <a href="https://github.com/nrwl/nx/blob/master/packages/nx/src/utils/find-matching-projects.ts">
+      <code>packages/nx/src/utils/find-matching-projects.ts</code>
+    </a>
+    . Compiles each project pattern once and caches the resulting regex.
+  </>
+);
+
+export const minimatchRedos = (
+  <>
+    GitHub advisory{' '}
+    <a href="https://github.com/advisories/GHSA-f8q6-p94x-37v3">
+      GHSA-f8q6-p94x-37v3
+    </a>{' '}
+    (CVE-2022-3517), High, CVSS 7.5, vector{' '}
+    <code>AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H</code>. ReDoS in{' '}
+    <code>braceExpand</code> for minimatch below 3.0.5.
+  </>
+);
+
+export const nxBraceExpansionBump = (
+  <>
+    Nx pull requests <a href="https://github.com/nrwl/nx/pull/36507">#36507</a>{' '}
+    (merged 29 July 2026, <code>brace-expansion</code> 5.0.6 to 5.0.8) and{' '}
+    <a href="https://github.com/nrwl/nx/pull/36577">#36577</a> (merged 5 August
+    2026, 5.0.8 to 5.0.9), both of them pins in the <code>overrides</code> block
+    of <code>pnpm-workspace.yaml</code> rather than a declared dependency. GitHub
+    advisory{' '}
+    <a href="https://github.com/advisories/GHSA-rgw5-rvv9-x895">
+      GHSA-rgw5-rvv9-x895
+    </a>{' '}
+    (CVE-2026-69152, High, CVSS 7.5), published 30 July 2026, records that the{' '}
+    <code>maxLength</code> mitigation added in 5.0.8 for CVE-2026-14257 was
+    incomplete. Both pins sit in 23.2.0 prereleases; the newest stable release is
+    23.1.2.
+  </>
+);
+
+export const socketNxAlerts = (
+  <>
+    Socket,{' '}
+    <a href="https://socket.dev/npm/package/nx/alerts/23.1.2">
+      package alerts for <code>nx</code> 23.1.2
+    </a>
+    , read 29 August 2026. Every alert quoted here is filed under the same
+    "supply chain risk" category.
+  </>
+);
+
+export const ejsSecurityPolicy = (
+  <>
+    EJS{' '}
+    <a href="https://github.com/mde/ejs/blob/main/SECURITY.md">
+      <code>SECURITY.md</code>
+    </a>
+    , which scopes out reports arising from passing unsanitized user input to
+    the render method.
+  </>
+);
+
+export const nvdDisputed = (
+  <>
+    NVD record for{' '}
+    <a href="https://nvd.nist.gov/vuln/detail/CVE-2023-29827">CVE-2023-29827</a>
+    , status <code>Analyzed</code>. The description carries the vendor's
+    dispute; the record still carries a Primary CVSS of 9.8 Critical assigned by{' '}
+    <code>nvd@nist.gov</code>.
+  </>
+);
+
+export const ghAdvisoryReview = (
+  <>
+    GitHub Docs,{' '}
+    <a href="https://docs.github.com/en/code-security/security-advisories/working-with-global-security-advisories-from-the-github-advisory-database/about-the-github-advisory-database">
+      About the GitHub Advisory Database
+    </a>
+    . Unreviewed advisories are published automatically from the NVD feed and do
+    not raise Dependabot alerts.
+  </>
+);
+
+export const csafVex = (
+  <>
+    OASIS,{' '}
+    <a href="https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html">
+      CSAF 2.0
+    </a>
+    , which defines the VEX profile a publisher uses to state that a product is
+    not affected by an advisory.
+  </>
+);
+
+export const npmAuditBrokenByDesign = (
+  <>
+    Dan Abramov,{' '}
+    <a href="https://overreacted.io/npm-audit-broken-by-design/">
+      npm audit: Broken by Design
+    </a>
+    , July 2021. Walks five advisories reported against a fresh Create React App
+    and finds none of them exploitable in that context.
+  </>
+);
+
+export const npmAuditLevel = (
+  <>
+    npm CLI documentation,{' '}
+    <a href="https://docs.npmjs.com/cli/v11/commands/npm-audit">
+      <code>npm audit</code>
+    </a>
+    . <code>--audit-level</code> sets the minimum severity that exits non-zero;{' '}
+    <code>--omit=dev</code> drops devDependencies from the report.
+  </>
+);
+
+export const curlSlop = (
+  <>
+    Daniel Stenberg,{' '}
+    <a href="https://daniel.haxx.se/blog/2025/07/14/death-by-a-thousand-slops/">
+      Death by a thousand slops
+    </a>
+    , July 2025. Roughly 20% of 2025 submissions were AI slop, at about two
+    security reports a week.
+  </>
+);
+
+export const curlBountyEnd = (
+  <>
+    Daniel Stenberg,{' '}
+    <a href="https://daniel.haxx.se/blog/2026/01/26/the-end-of-the-curl-bug-bounty/">
+      The end of the curl bug-bounty
+    </a>
+    , January 2026. Seven years, 87 confirmed vulnerabilities, over 100,000 USD
+    paid, closed to GitHub private disclosure and email on 31 January 2026.
+  </>
+);
+
+export const larsonSlop = (
+  <>
+    Seth Larson,{' '}
+    <a href="https://sethmlarson.dev/slop-security-reports">
+      Please stop submitting AI slop security reports
+    </a>
+    , December 2024. Larson triages security reports for CPython, pip, urllib3
+    and Requests.
+  </>
+);
+
+export const xzMaintainerThread = (
+  <>
+    xz-devel mailing list,{' '}
+    <a href="https://www.mail-archive.com/xz-devel@tukaani.org/msg00567.html">
+      message from Lasse Collin
+    </a>
+    , 8 June 2022, answering an account posting under the name Jigar Kumar.
+  </>
+);
+
+export const xzBackdoor = (
+  <>
+    <a href="https://nvd.nist.gov/vuln/detail/CVE-2024-3094">CVE-2024-3094</a>.
+    Malicious code introduced into the xz upstream releases by an account that
+    had spent roughly two years gaining commit access.
+  </>
+);
+
+# BS CVEs and Maintainer Burnout
+
+A Critical advisory lands against a package in your dependency tree. The gate goes red, a ticket opens somewhere downstream, and somebody has to work out whether it means anything.
+
+Most of the time it does not. Finding that out is the expensive part, the fix ships anyway, and nothing about the software is safer than it was before.
+
+<Callout title="About the examples">
+
+Nx is the open source repository I work in every day, which makes it the one I can show you call sites from. The same alerts land on any task runner, bundler or test framework.
+
+Nothing here says Nx is unsafe, or that the Nx team mishandles security. We read every report, work out whether it reaches us, and bump so nobody downstream carries something we could have taken off them. The complaint is about what the process costs to run, not whether to run it.
+
+</Callout>
+
+## Where the number comes from
+
+Almost every advisory arrives with conditions attached. Something has to be handed a particular option, or reached from a request, before the bug is a bug at all.
+
+CVSS scores the worst context anyone can construct, which is the right question for a library that renders web responses for strangers. The database stores one score, and every consumer downstream reads that one. A CLI running on your laptop against files you wrote has a different threat model than an Express handler, and there is no field for that.
+
+## What the scanner does with it
+
+`npm audit`, Socket and Dependabot do not check the conditions either. They check whether an installed version falls inside the affected range, because checking conditions would mean resolving your call graph. For a library reached over the network, installed and reachable mostly coincide. For developer tooling they come apart, in two different ways.
+
+### Installed is not reachable
+
+Nx uses EJS to expand generator templates, and that is the only thing it uses EJS for. The call site is three lines:<Cite href="https://github.com/nrwl/nx/blob/master/packages/devkit/src/generators/generate-files.ts">{nxGenerateFiles}</Cite>
+
+```ts filename="packages/devkit/src/generators/generate-files.ts"
+newContent = ejs.render(template, substitutions, {
+  filename: filePath,
+});
+```
+
+CVE-2023-29827 is rated 9.8 Critical: template injection through the `closeDelimiter` option, which lets you break out of the template and run arbitrary code.<Cite href="https://github.com/advisories/GHSA-j5pp-6f4w-r5r6">{ejsClosedelimiterCve}</Cite> A newer report does the same through `escapeFunction`.<Cite href="https://github.com/mde/ejs/issues/735">{ejsEscapefunctionIssue}</Cite>
+
+Both need an attacker to control the options object. Here it is a literal in the source with one key, and the key is the path of the file being rendered. The templates ship inside the generator package the developer installed, and `substitutions` are answers they typed into their own terminal. Editing any of that means already having write access to the developer's disk, and anyone who has that has better options than EJS.
+
+The pin reads `"ejs": "5.0.1"` anyway, a bump that landed in Nx 22.7.0.<Cite href="https://github.com/nrwl/nx/pull/35157">{nxEjsBump}</Cite>
+
+### Reachable is not exploitable
+
+This one is different: the path is reachable and the bug fires exactly as written up. Nx works out which projects a command applies to by compiling patterns with minimatch:<Cite href="https://github.com/nrwl/nx/blob/master/packages/nx/src/utils/find-matching-projects.ts">{nxFindMatchingProjects}</Cite>
+
+```ts filename="packages/nx/src/utils/find-matching-projects.ts"
+const regex = minimatch.makeRe(pattern, { dot: true });
+```
+
+Compiling a pattern runs brace expansion, which is where CVE-2022-3517 lives. A crafted pattern sends `braceExpand` into catastrophic backtracking and pins a core, scored 7.5 High for an attacker who reaches it over the network with no privileges and no user interaction.<Cite href="https://github.com/advisories/GHSA-f8q6-p94x-37v3">{minimatchRedos}</Cite>
+
+The pattern comes from `nx.json` or a `--projects` flag somebody typed. Exploiting it means putting a pathological glob in your own config on your own laptop and waiting while your own build hangs. You are the only victim, and you find out in the ten seconds before you kill the process and fix the glob.
+
+Every build tool that has ever expanded `src/**/*.ts` gets handed the same 7.5. minimatch delegates brace expansion to `brace-expansion`, which Nx pins by override, and that pin moved twice in a week when the version it took on 29 July was called incomplete the next day.<Cite href="https://github.com/nrwl/nx/pull/36577">{nxBraceExpansionBump}</Cite>
+
+## What lands on the maintainer
+
+Both of those took reading a call site to settle. A scanner that does read the code hands over a different problem, and not a smaller one.
+
+### The alerts that describe the product
+
+Nx is a task runner. Running the commands in your config is the entire product, and Socket's alert page is a fair summary of what a scanner makes of that:
+
+<Quote href="https://socket.dev/npm/package/nx/alerts/23.1.2" by="Socket" work="package alerts for nx 23.1.2" cite={socketNxAlerts}>
+
+Shell access. This module accesses the system shell. Accessing the system shell increases the risk of executing arbitrary code.
+
+</Quote>
+
+Accurate, and load-bearing. `Install scripts`, `Network access`, `Dynamic require` and `Debug access` sit beside it, each describing something a build tool does on purpose. A developer installs Nx precisely so that it will access the system shell, and there is no version to bump to. The finding recurs on every scan for as long as the package does what it says on the tin.
+
+### The alerts that need an afternoon
+
+Above all of those, at the top of the list:
+
+<Quote href="https://socket.dev/npm/package/nx/alerts/23.1.2" by="Socket" work="package alerts for nx 23.1.2">
+
+AI-detected potential security risk. AI has determined that this package may contain potential security issues or vulnerabilities. Found 4 instances.
+
+</Quote>
+
+Behind that summary, each instance carries a confidence score, an impact score, the file it fired on, and a paragraph of reasoning. One flags `v8.deserialize` on socket payloads. Another flags `execSync` on a command string assembled from CLI arguments. That is a good deal more than the summary line suggests, and the summary line is what reaches a dashboard.
+
+Working out whether any of it reaches you means finding each call site and reasoning about who can supply the input.
+
+For those four that was an afternoon, and most of the threat models did not survive contact with the code: the socket is a unix socket the daemon chmods to `0600`, and the commands come from config files in your own repository. That afternoon is not free, and nothing in the pipeline that raised the alert helps you spend it.
+
+## What you cannot do about it
+
+Having spent the afternoon, a maintainer has three moves, and all three are worth roughly nothing.
+
+### Draw a boundary
+
+The EJS maintainers wrote their position down. Their security policy says that giving end users unfettered access to the render method is "using EJS in an inherently un-secure way", and that "EJS is effectively a JavaScript runtime. Its entire job is to execute JavaScript."<Cite href="https://github.com/mde/ejs/blob/main/SECURITY.md">{ejsSecurityPolicy}</Cite> That is a boundary drawn in public, in the file the process tells you to read, and reports keep arriving anyway.
+
+### File a dispute
+
+Disputing is allowed and accomplishes very little. NVD records the dispute for CVE-2023-29827 in the description itself:
+
+{/* vale proselint.Annotations = NO */}
+
+<Quote href="https://nvd.nist.gov/vuln/detail/CVE-2023-29827" by="NVD" work="record for CVE-2023-29827" cite={nvdDisputed}>
+
+NOTE: this is disputed by the vendor because the render function is not intended to be used with untrusted input.
+
+</Quote>
+
+{/* vale proselint.Annotations = YES */}
+
+That same record carries a Primary CVSS of 9.8 Critical, assigned by NVD. The dispute is prose. The score is a field. GitHub marks the advisory Unreviewed so Dependabot skips it, and every scanner pulling from NVD directly still reports the 9.8.<Cite href="https://docs.github.com/en/code-security/security-advisories/working-with-global-security-advisories-from-the-github-advisory-database/about-the-github-advisory-database">{ghAdvisoryReview}</Cite>
+
+### Publish a VEX
+
+VEX and CSAF let a publisher declare a product unaffected by an advisory, which is exactly the statement a maintainer wants to make.<Cite href="https://docs.oasis-open.org/csaf/csaf/v2.0/csaf-v2.0.html">{csafVex}</Cite> Consuming-side adoption is thin enough that publishing one gets you out of nothing today.
+
+## What ships
+
+A published advisory naming your package is permanent, and most people who meet it will never read your explanation. "Critical RCE in your-package" travels further than any threat model you write down.
+
+Nobody is penalized for over-reporting, and a maintainer who declines to bump inherits every downstream user's compliance ticket. Those users are not filing because they read the advisory and disagreed. They are filing because their scanner failed their pipeline and you are the name attached to it.
+
+You bump, and most of the time it is cheap: the fixed version already sits inside the declared range, so it costs a lockfile line and a patch release. Sometimes there is nothing to bump to, as with GHSA-j5pp-6f4w-r5r6, which lists no patched version at all. Either way the release buys no security. It buys a green scanner.
+
+## Some caveats
+
+Bump anyway, most of the time. The release is cheap, and a reachability argument that turns out to be wrong costs more than a version number you did not need. Mine has a shelf life: one pull request threading a caller-supplied options object into that render call makes me wrong, and nothing will tell me.
+
+## Who pays
+
+### The user learns to ignore it
+
+Dan Abramov went through five advisories against a fresh Create React App in 2021. None were exploitable there, and he named the real damage:
+
+<Quote href="https://overreacted.io/npm-audit-broken-by-design/" by="Dan Abramov" work="npm audit: Broken by Design" cite={npmAuditBrokenByDesign}>
+
+Someday, it will make our users miserable because we have trained an entire generation of developers to either not understand the warnings due to being overwhelmed, or to simply ignore them because they always show up but the experienced developers (correctly) tell them there is no real issue.
+
+</Quote>
+
+The training worked, and the tooling shipped the evidence:
+
+- `--audit-level`, so a team can pick a severity beneath which the output stops failing the build.
+- `--omit=dev`, so build-time packages stop counting at all.
+
+Those flags exist because the output was unusable without them.<Cite href="https://docs.npmjs.com/cli/v11/commands/npm-audit">{npmAuditLevel}</Cite> Past that come the local habits: the audit step piped to `true`, the allowlist entry that outlives everyone who understood why it was added. Every one of those is a rational response to a channel that has never carried anything worth reading.
+
+### The maintainer goes quiet
+
+The other half of the bill goes to whoever answers. Through 2025 about a fifth of curl's security submissions were AI slop, at roughly two a week, and the share that turned out to be real fell from north of 15% to under 5%.<Cite href="https://daniel.haxx.se/blog/2025/07/14/death-by-a-thousand-slops/">{curlSlop}</Cite>
+
+Each one has to be read by somebody who can tell, and Stenberg puts the cost at three or four people per report, thirty minutes to three hours each, on a submission that describes nothing.
+
+<Quote href="https://daniel.haxx.se/blog/2025/07/14/death-by-a-thousand-slops/" by="Daniel Stenberg" work="Death by a thousand slops">
+
+The never-ending slop submissions take a serious mental toll to manage and sometimes also a long time to debunk.
+
+</Quote>
+
+In January 2026 curl ended its bug bounty. Seven years, 87 confirmed vulnerabilities, more than 100,000 USD paid out, shut down because the reports stopped being worth reading.<Cite href="https://daniel.haxx.se/blog/2026/01/26/the-end-of-the-curl-bug-bounty/">{curlBountyEnd}</Cite> The program did not end because curl ran out of bugs. It ended because finding them stopped being possible at a price anyone would pay.
+
+Seth Larson, who triages security reports for CPython, pip, urllib3 and Requests, named where that ends:
+
+<Quote href="https://sethmlarson.dev/slop-security-reports" by="Seth Larson" work="Please stop submitting AI slop security reports" cite={larsonSlop}>
+
+even if this is not their intent, the outcome is maintainers that are burnt out and more averse to legitimate security work.
+
+</Quote>
+
+Attention is the scarce resource in maintenance, and every part of this spends it on reports that turn out to be nothing. People go quiet, or hand the keys to whoever volunteers. The handover is the dangerous one. In June 2022 the maintainer of xz was being told in public that he had "lost interest or doesn't care to maintain anymore", and answered:
+
+{/* vale Vale.Spelling = NO */}
+
+<Quote href="https://www.mail-archive.com/xz-devel@tukaani.org/msg00567.html" by="Lasse Collin" work="xz-devel mailing list, 8 June 2022" cite={xzMaintainerThread}>
+
+I haven't lost interest but my ability to care has been fairly limited mostly due to longterm mental health issues but also due to some other things.
+
+</Quote>
+
+{/* vale Vale.Spelling = YES */}
+
+The account applying that pressure is widely assessed to have belonged to the operation that put a backdoor in xz two years later, as CVE-2024-3094.<Cite href="https://nvd.nist.gov/vuln/detail/CVE-2024-3094">{xzBackdoor}</Cite> That campaign was about release velocity rather than advisory noise, so I am not claiming `npm audit` produced it. The resource it drained is the same one. A maintainer's attention is a security property of the package, and the current process treats it as free.
+
+## Conclusion
+
+Socket and Snyk both sell reachability analysis, which asks a better question than `npm audit` does. It is not what most CI gates run.
+
+The scanner asks whether a version is installed. The maintainer has to answer whether anyone can actually do the thing. Until the second question is as cheap as the first, the difference gets paid in releases that change nothing and in the people who stop answering. The advisories that do apply arrive through the same channel, at whoever is left.
+
+<Citations />

--- a/libs/blog-posts/src/lib/posts/bs-cves-and-maintainer-burnout/post.ts
+++ b/libs/blog-posts/src/lib/posts/bs-cves-and-maintainer-burnout/post.ts
@@ -1,0 +1,11 @@
+import { BlogPost, BlogTag } from '../../blog-post';
+import mdx from './contents.mdx';
+
+export const bsCvesAndMaintainerBurnout: BlogPost = {
+  mdx,
+  publishDate: new Date(2026, 8, 15),
+  slug: 'bs-cves-and-maintainer-burnout',
+  title: 'BS CVEs and Maintainer Burnout',
+  description: `An advisory scored for someone else's threat model fails your build, and the only party who can say whether it matters is a maintainer with an afternoon to spend. Worked examples from Nx where the answer was no, the three ways of saying so that accomplish nothing, and why curl ended a seven-year bug bounty in January 2026.`,
+  tags: ['technical', 'tooling', 'devops', 'nx'] as BlogTag[],
+};

--- a/libs/blog-posts/src/lib/posts/github-pages-preview-env/contents.mdx
+++ b/libs/blog-posts/src/lib/posts/github-pages-preview-env/contents.mdx
@@ -2,8 +2,6 @@
 
 GitHub Pages provides free hosting for static websites. It's a great way to host your personal blog, portfolio, or documentation, and is in fact used to host this website. While it serves this purpose well, it is missing a feature that many newer hosting providers offer: preview environments.
 
-## Table of Contents
-
 ## What are preview environments?
 
 Preview environments are temporary environments that are created for each pull request. They allow you to preview your changes before merging them into the main branch. This is especially useful for static websites, where you can't preview your changes locally. Vercel and Netlify both offer this feature, and leave a comment on the pull request with a link to the preview environment.

--- a/libs/blog-posts/src/lib/posts/index.ts
+++ b/libs/blog-posts/src/lib/posts/index.ts
@@ -1,3 +1,4 @@
+import { bsCvesAndMaintainerBurnout } from './bs-cves-and-maintainer-burnout/post';
 import { githubPagesPreviewEnv } from './github-pages-preview-env/post';
 import { githubUnlistedRepos } from './github-unlisted-repos/post';
 import { multifunctionExampleFiles } from './multifunctional-example-files/post';
@@ -25,6 +26,7 @@ function partition<T extends unknown[]>(arr: T, size: number): T[] {
 }
 
 const ALL_BLOG_POSTS = [
+  bsCvesAndMaintainerBurnout,
   nxConfigurationHistory,
   githubPagesPreviewEnv,
   superpoweredGitAliases,

--- a/libs/blog-posts/src/lib/posts/nx-configuration-history/contents.mdx
+++ b/libs/blog-posts/src/lib/posts/nx-configuration-history/contents.mdx
@@ -1,7 +1,5 @@
 # Nx: From Angular Roots to Crystal Future
 
-## Table of Contents
-
 ## Introduction
 
 Nx's configuration has changed dramatically over the years, and it's been a long journey to get to where we are today. I joined the Nx team in June 2021, right before we split up `workspace.json` into `workspace.json` and `project.json`. Since joining the team, I've had a pretty direct hand in many of these changes, and have worked closely on others.

--- a/libs/blog-posts/src/lib/posts/package-manager-release-cooldown/contents.mdx
+++ b/libs/blog-posts/src/lib/posts/package-manager-release-cooldown/contents.mdx
@@ -209,8 +209,6 @@ export const pnpmTrustPolicy = (
 
 A minimum release age (or "cooldown") instructs a package manager to ignore any dependency version published less than a configured amount of time ago. The reference below covers the cooldown, install-time lifecycle script gating, and pnpm's trust policy across the four major Node.js package managers; the setting names and units differ in each.
 
-## Table of Contents
-
 ## Overview
 
 {/* vale write-good.Weasel = NO */}
@@ -221,10 +219,10 @@ A cooldown delays a freshly published version from being installable. Compromise
 
 Each tool exposes the setting under its own name and unit of time:
 
-- **npm**: `min-release-age`, in **days**. npm CLI **11.10.0** (February 2026).<Cite n={1} href="https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age">{npmDocs}</Cite>
-- **pnpm**: `minimumReleaseAge`, in **minutes**. pnpm **10.16** (September 2025); default `1440` since pnpm **11.0**.<Cite n={2} href="https://pnpm.io/settings#minimumreleaseage">{pnpmDocs}</Cite>
-- **Yarn**: `npmMinimalAgeGate`, in **minutes**. Yarn Berry **4.10.0**.<Cite n={3} href="https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate">{yarnDocs}</Cite>
-- **Bun**: `minimumReleaseAge`, in **seconds**. Bun **1.3.0**.<Cite n={4} href="https://bun.sh/docs/runtime/bunfig#install-minimumreleaseage">{bunDocs}</Cite>
+- **npm**: `min-release-age`, in **days**. npm CLI **11.10.0** (February 2026).<Cite href="https://docs.npmjs.com/cli/v11/using-npm/config#min-release-age">{npmDocs}</Cite>
+- **pnpm**: `minimumReleaseAge`, in **minutes**. pnpm **10.16** (September 2025); default `1440` since pnpm **11.0**.<Cite href="https://pnpm.io/settings#minimumreleaseage">{pnpmDocs}</Cite>
+- **Yarn**: `npmMinimalAgeGate`, in **minutes**. Yarn Berry **4.10.0**.<Cite href="https://yarnpkg.com/configuration/yarnrc#npmMinimalAgeGate">{yarnDocs}</Cite>
+- **Bun**: `minimumReleaseAge`, in **seconds**. Bun **1.3.0**.<Cite href="https://bun.sh/docs/runtime/bunfig#install-minimumreleaseage">{bunDocs}</Cite>
 
 The setting can be written per-project or per-user. A per-project value protects the codebase against newly published policy violations; a user-wide value extends the cooldown to repositories that have not opted in. Both are worth setting; neither replaces the other, and the conditions under which either is silently bypassed are listed in the [caveats](#caveats) below.
 
@@ -272,7 +270,7 @@ On pnpm 10.x, the same setting is written in `.npmrc` with a different casing:
 minimum-release-age=1440
 ```
 
-A known bug on pnpm 10.x causes `minimumReleaseAge` to be silently ignored when any package in the workspace sets `shared-workspace-lockfile=false` in its `.npmrc`.<Cite n={8} href="https://github.com/pnpm/pnpm/issues/10008">{pnpmLockfileBug}</Cite> On 10.x, this is worth verifying before assuming the setting is honored.
+A known bug on pnpm 10.x causes `minimumReleaseAge` to be silently ignored when any package in the workspace sets `shared-workspace-lockfile=false` in its `.npmrc`.<Cite href="https://github.com/pnpm/pnpm/issues/10008">{pnpmLockfileBug}</Cite> On 10.x, this is worth verifying before assuming the setting is honored.
 
 </Tab>
 <Tab label="Yarn">
@@ -293,7 +291,7 @@ npmPreapprovedPackages:
 
 `npmPreapprovedPackages` accepts both glob patterns and exact locators (for example, `@aws-sdk/types@3.877.0`), giving it more granularity than pnpm's package-name-only exclude list.
 
-The documentation states that a duration suffix such as `"7d"` is accepted, but a known parsing bug causes the suffix to be dropped.<Cite n={9} href="https://github.com/yarnpkg/berry/issues/6991">{yarnSuffixBug}</Cite> Until that is resolved, a plain minute count is the reliable form: one day is `npmMinimalAgeGate: 1440`.
+The documentation states that a duration suffix such as `"7d"` is accepted, but a known parsing bug causes the suffix to be dropped.<Cite href="https://github.com/yarnpkg/berry/issues/6991">{yarnSuffixBug}</Cite> Until that is resolved, a plain minute count is the reliable form: one day is `npmMinimalAgeGate: 1440`.
 
 </Tab>
 <Tab label="Bun">
@@ -338,7 +336,7 @@ This writes to `~/.npmrc`. Substituting `global` for `user` writes to the global
 pnpm config set minimumReleaseAge 1440 --location=user
 ```
 
-On pnpm 11 and later, non-auth settings written this way land in a global `config.yaml` whose location is platform-specific: `~/.config/pnpm/config.yaml` on Linux, `~/Library/Preferences/pnpm/config.yaml` on macOS, and `~/AppData/Local/pnpm/config/config.yaml` on Windows. Setting `$XDG_CONFIG_HOME` moves the file to `$XDG_CONFIG_HOME/pnpm/config.yaml` on every platform, macOS included.<Cite n={19} href="https://pnpm.io/cli/config">{pnpmConfigLocations}</Cite>
+On pnpm 11 and later, non-auth settings written this way land in a global `config.yaml` whose location is platform-specific: `~/.config/pnpm/config.yaml` on Linux, `~/Library/Preferences/pnpm/config.yaml` on macOS, and `~/AppData/Local/pnpm/config/config.yaml` on Windows. Setting `$XDG_CONFIG_HOME` moves the file to `$XDG_CONFIG_HOME/pnpm/config.yaml` on every platform, macOS included.<Cite href="https://pnpm.io/cli/config">{pnpmConfigLocations}</Cite>
 
 The platform split makes hand-editing risky: a `config.yaml` written to the Linux path on a Mac sits in a file pnpm never reads, and nothing warns about it. Auth and registry settings follow the same directory rules but go to a sibling `rc` file in INI format — and on pnpm 11, that INI file is consulted _only_ for auth and registry keys, so a `minimum-release-age=` line carried over from pnpm 10 is silently ignored as well. Writing through `pnpm config set --location=user` targets the correct file on every OS, and running `pnpm config get minimumReleaseAge` from outside any project confirms the value is actually being read back.
 
@@ -354,14 +352,14 @@ yarn config set --home npmMinimalAgeGate 1440
 </Tab>
 <Tab label="Bun">
 
-The same `[install]` table written in a user-wide bunfig applies across projects. Bun reads `~/.bunfig.toml` — or `$XDG_CONFIG_HOME/.bunfig.toml` when that variable is set — and merges it with the project file, with the project file winning on conflicting keys:<Cite n={20} href="https://bun.sh/docs/runtime/bunfig#global-vs-local">{bunGlobalBunfig}</Cite>
+The same `[install]` table written in a user-wide bunfig applies across projects. Bun reads `~/.bunfig.toml` — or `$XDG_CONFIG_HOME/.bunfig.toml` when that variable is set — and merges it with the project file, with the project file winning on conflicting keys:<Cite href="https://bun.sh/docs/runtime/bunfig#global-vs-local">{bunGlobalBunfig}</Cite>
 
 ```toml filename="~/.bunfig.toml"
 [install]
 minimumReleaseAge = 86400
 ```
 
-The merge is per-key, so a project `bunfig.toml` that sets an unrelated `[install]` option (for example, `install.exact`) still inherits the user-wide cooldown. A machine-wide layer below both files (`/etc/bunfig.toml`), aimed at fleet-level enforcement, is proposed in an open pull request.<Cite n={10} href="https://github.com/oven-sh/bun/pull/28727">{bunSystemWidePr}</Cite>
+The merge is per-key, so a project `bunfig.toml` that sets an unrelated `[install]` option (for example, `install.exact`) still inherits the user-wide cooldown. A machine-wide layer below both files (`/etc/bunfig.toml`), aimed at fleet-level enforcement, is proposed in an open pull request.<Cite href="https://github.com/oven-sh/bun/pull/28727">{bunSystemWidePr}</Cite>
 
 </Tab>
 </Tabs>
@@ -381,18 +379,18 @@ ignore-scripts=true
 
 This disables lifecycle scripts for all dependencies, but it also affects the project's own hooks: `npm run`, `npm start`, and `npm test` still execute the named script, but skip its pre- and post-scripts.
 
-npm **11.16.0** adds a granular alternative: an `allowScripts` field in `package.json`, managed with `npm approve-scripts` and `npm deny-scripts`.<Cite n={11} href="https://docs.npmjs.com/cli/v11/commands/npm-approve-scripts">{npmApproveScripts}</Cite> On npm 11 the field is advisory — unreviewed install scripts still run, and the install prints a warning listing them. Enforcement is opt-in:
+npm **11.16.0** adds a granular alternative: an `allowScripts` field in `package.json`, managed with `npm approve-scripts` and `npm deny-scripts`.<Cite href="https://docs.npmjs.com/cli/v11/commands/npm-approve-scripts">{npmApproveScripts}</Cite> On npm 11 the field is advisory — unreviewed install scripts still run, and the install prints a warning listing them. Enforcement is opt-in:
 
 ```INI filename=".npmrc"
 strict-allow-scripts=true
 ```
 
-npm v12 (estimated July 2026) makes enforcement the default: install scripts from dependencies will not run unless explicitly allowed, and git and remote-URL dependencies will not resolve unless `--allow-git` or `--allow-remote` is granted.<Cite n={12} href="https://github.com/orgs/community/discussions/198547">{npmV12Plan}</Cite>
+npm v12 (estimated July 2026) makes enforcement the default: install scripts from dependencies will not run unless explicitly allowed, and git and remote-URL dependencies will not resolve unless `--allow-git` or `--allow-remote` is granted.<Cite href="https://github.com/orgs/community/discussions/198547">{npmV12Plan}</Cite>
 
 </Tab>
 <Tab label="pnpm">
 
-Since pnpm 10, dependency build scripts do not run unless approved. `pnpm approve-builds` walks through the dependencies that want to run them, and the approvals are recorded in the `allowBuilds` map (pnpm 10.26 and later; it replaces `onlyBuiltDependencies` and `neverBuiltDependencies` in pnpm 11):<Cite n={13} href="https://pnpm.io/settings#allowbuilds">{pnpmAllowBuilds}</Cite>
+Since pnpm 10, dependency build scripts do not run unless approved. `pnpm approve-builds` walks through the dependencies that want to run them, and the approvals are recorded in the `allowBuilds` map (pnpm 10.26 and later; it replaces `onlyBuiltDependencies` and `neverBuiltDependencies` in pnpm 11):<Cite href="https://pnpm.io/settings#allowbuilds">{pnpmAllowBuilds}</Cite>
 
 ```yaml filename="pnpm-workspace.yaml"
 allowBuilds:
@@ -411,7 +409,7 @@ Packages not listed are not built. `strictDepBuilds` (default `true`) fails the 
 enableScripts: false
 ```
 
-`false` is the default since Yarn **4.14.0**; every earlier release defaulted to `true`.<Cite n={18} href="https://github.com/yarnpkg/berry/pull/7089">{yarnEnableScriptsDefaultPr}</Cite> The 4.14 migration also preserves old behavior by writing an explicit `enableScripts: true` into existing projects, so a repository upgraded across the flip stays opted in until that line is removed. Both conditions argue for setting `false` explicitly rather than relying on the default. Individual packages are opted back in through `dependenciesMeta` in `package.json`, which acts as an allowlist while scripts are globally disabled:<Cite n={14} href="https://yarnpkg.com/configuration/yarnrc#enableScripts">{yarnEnableScripts}</Cite>
+`false` is the default since Yarn **4.14.0**; every earlier release defaulted to `true`.<Cite href="https://github.com/yarnpkg/berry/pull/7089">{yarnEnableScriptsDefaultPr}</Cite> The 4.14 migration also preserves old behavior by writing an explicit `enableScripts: true` into existing projects, so a repository upgraded across the flip stays opted in until that line is removed. Both conditions argue for setting `false` explicitly rather than relying on the default. Individual packages are opted back in through `dependenciesMeta` in `package.json`, which acts as an allowlist while scripts are globally disabled:<Cite href="https://yarnpkg.com/configuration/yarnrc#enableScripts">{yarnEnableScripts}</Cite>
 
 ```json filename="package.json"
 {
@@ -421,12 +419,12 @@ enableScripts: false
 }
 ```
 
-Yarn also ships `enableHardenedMode`, which re-validates lockfile resolutions and checksums against the remote registry during install. It is enabled automatically on pull requests from public GitHub repositories and can be forced on for any branch edited from outside the circle of trust.<Cite n={15} href="https://yarnpkg.com/configuration/yarnrc#enableHardenedMode">{yarnHardenedMode}</Cite>
+Yarn also ships `enableHardenedMode`, which re-validates lockfile resolutions and checksums against the remote registry during install. It is enabled automatically on pull requests from public GitHub repositories and can be forced on for any branch edited from outside the circle of trust.<Cite href="https://yarnpkg.com/configuration/yarnrc#enableHardenedMode">{yarnHardenedMode}</Cite>
 
 </Tab>
 <Tab label="Bun">
 
-Bun is default-secure here: lifecycle scripts only run for packages on a curated default trusted list, and only when those packages are installed from npm. Additional packages are trusted via `trustedDependencies` in `package.json`:<Cite n={16} href="https://bun.sh/docs/install/lifecycle">{bunLifecycle}</Cite>
+Bun is default-secure here: lifecycle scripts only run for packages on a curated default trusted list, and only when those packages are installed from npm. Additional packages are trusted via `trustedDependencies` in `package.json`:<Cite href="https://bun.sh/docs/install/lifecycle">{bunLifecycle}</Cite>
 
 ```json filename="package.json"
 {
@@ -446,7 +444,7 @@ ignoreScripts = true
 
 ## pnpm's trust policy
 
-pnpm 10.21 adds a check orthogonal to both the cooldown and script gating. With `trustPolicy` set to `no-downgrade`, the install fails if a package's trust level has decreased relative to its earlier releases — for example, a package whose previous versions carried provenance attestations suddenly shipping a version without one.<Cite n={17} href="https://pnpm.io/settings#trustpolicy">{pnpmTrustPolicy}</Cite> That signature is characteristic of a stolen-token compromise: the attacker publishes from their own machine, and the provenance that the maintainer's CI pipeline would have attached is missing.
+pnpm 10.21 adds a check orthogonal to both the cooldown and script gating. With `trustPolicy` set to `no-downgrade`, the install fails if a package's trust level has decreased relative to its earlier releases — for example, a package whose previous versions carried provenance attestations suddenly shipping a version without one.<Cite href="https://pnpm.io/settings#trustpolicy">{pnpmTrustPolicy}</Cite> That signature is characteristic of a stolen-token compromise: the attacker publishes from their own machine, and the provenance that the maintainer's CI pipeline would have attached is missing.
 
 ```yaml filename="pnpm-workspace.yaml"
 trustPolicy: no-downgrade
@@ -458,17 +456,17 @@ Two companion settings handle false positives. `trustPolicyExclude` (pnpm 10.22)
 
 A handful of conditions can quietly bypass the configured cooldown or change what is actually being honored.
 
-**The check runs at install time, not when an updater opens a PR.** Renovate and Dependabot evaluate updates independently of the package manager's cooldown, so their own cooldown options must be set separately. Both ship reasonable defaults: Renovate's `config:best-practices` preset waits three days before raising an npm update,<Cite n={5} href="https://docs.renovatebot.com/presets-config/#configbest-practices">{renovateBestPractices}</Cite> and Dependabot exposes `cooldown.default-days` with semver-specific overrides.<Cite n={6} href="https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown">{dependabotCooldown}</Cite>
+**The check runs at install time, not when an updater opens a PR.** Renovate and Dependabot evaluate updates independently of the package manager's cooldown, so their own cooldown options must be set separately. Both ship reasonable defaults: Renovate's `config:best-practices` preset waits three days before raising an npm update,<Cite href="https://docs.renovatebot.com/presets-config/#configbest-practices">{renovateBestPractices}</Cite> and Dependabot exposes `cooldown.default-days` with semver-specific overrides.<Cite href="https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#cooldown">{dependabotCooldown}</Cite>
 
 **A repository's pinned package manager is what actually runs the install.** A pin via the `packageManager` field, Corepack, Volta, a Docker base image, or `setup-node` with `version-file` overrides whatever is installed globally. If the pinned version predates cooldown support, every layer of configuration above it is inert. The most reliable check is to run `pnpm --version` (or the equivalent) from inside the repository, or to inspect the `setup-node` step in the CI log.
 
 **Project-level configuration takes precedence over user-level configuration in all four tools.** A user-wide cooldown of one day does not apply inside a repository whose project config sets a smaller value or none at all. A user-wide value is not a backstop for repositories that have not opted in.
 
-**The user-wide file lives at a different path per operating system for pnpm and Bun.** npm and Yarn read `~/.npmrc` and `~/.yarnrc.yml` from the home directory everywhere, but pnpm's global `config.yaml` moves between `~/.config/pnpm/` (Linux), `~/Library/Preferences/pnpm/` (macOS), and `~/AppData/Local/pnpm/config/` (Windows),<Cite n={19} href="https://pnpm.io/cli/config">{pnpmConfigLocations}</Cite> and Bun switches from `~/.bunfig.toml` to `$XDG_CONFIG_HOME/.bunfig.toml` when the variable is set. A config file hand-written to the path from another operating system's documentation is silently ignored. Writing through the tool's own CLI and then reading the value back from outside any project confirms the setting landed somewhere it will actually be read.
+**The user-wide file lives at a different path per operating system for pnpm and Bun.** npm and Yarn read `~/.npmrc` and `~/.yarnrc.yml` from the home directory everywhere, but pnpm's global `config.yaml` moves between `~/.config/pnpm/` (Linux), `~/Library/Preferences/pnpm/` (macOS), and `~/AppData/Local/pnpm/config/` (Windows),<Cite href="https://pnpm.io/cli/config">{pnpmConfigLocations}</Cite> and Bun switches from `~/.bunfig.toml` to `$XDG_CONFIG_HOME/.bunfig.toml` when the variable is set. A config file hand-written to the path from another operating system's documentation is silently ignored. Writing through the tool's own CLI and then reading the value back from outside any project confirms the setting landed somewhere it will actually be read.
 
-**None of the four tools support per-registry scoping.** Internal packages from a private registry are subject to the cooldown unless explicitly listed in the per-tool exclusion option. npm does not yet expose one; an issue is open against the CLI tracking it.<Cite n={7} href="https://github.com/npm/cli/issues/8994">{npmExcludeIssue}</Cite>
+**None of the four tools support per-registry scoping.** Internal packages from a private registry are subject to the cooldown unless explicitly listed in the per-tool exclusion option. npm does not yet expose one; an issue is open against the CLI tracking it.<Cite href="https://github.com/npm/cli/issues/8994">{npmExcludeIssue}</Cite>
 
-**Defaults are shifting upward.** pnpm 11 ships with the gate enabled at 1440 minutes by default,<Cite n={2} href="https://pnpm.io/settings#minimumreleaseage">{pnpmDocs}</Cite> and npm v12 is set to make install scripts and non-registry dependency sources opt-in.<Cite n={12} href="https://github.com/orgs/community/discussions/198547">{npmV12Plan}</Cite> Setting explicit values insulates the configured behavior against changes elsewhere in the ecosystem.
+**Defaults are shifting upward.** pnpm 11 ships with the gate enabled at 1440 minutes by default,<Cite href="https://pnpm.io/settings#minimumreleaseage">{pnpmDocs}</Cite> and npm v12 is set to make install scripts and non-registry dependency sources opt-in.<Cite href="https://github.com/orgs/community/discussions/198547">{npmV12Plan}</Cite> Setting explicit values insulates the configured behavior against changes elsewhere in the ecosystem.
 
 ## Acknowledgements
 
@@ -476,3 +474,5 @@ This digest closely follows two gists that did the original work of pulling the 
 
 - Matteo Collina, <a href="https://gist.github.com/mcollina/b294a6c39ee700d24073c0e5a4e93104" target="_blank" rel="noopener noreferrer">"Configuring minimum release age across npm, pnpm, and yarn"</a> (April 2026). The original write-up covering npm, pnpm, and Yarn.
 - Tom Ricci, <a href="https://gist.github.com/tom-ricci/bade55606ebb7a550598f11e29f1d6b0" target="_blank" rel="noopener noreferrer">"Configuring minimum release age across npm, pnpm, yarn, and bun"</a>. Extended Collina's notes with Bun coverage and the per-tool exclusion options.
+
+<Citations />

--- a/libs/blog-posts/src/lib/posts/superpowered-git-aliases/contents.mdx
+++ b/libs/blog-posts/src/lib/posts/superpowered-git-aliases/contents.mdx
@@ -1,7 +1,5 @@
 # Superpowered Git Aliases using Scripting
 
-## Table of Contents
-
 ## What are Git Aliases
 
 Git aliases work similarly to regular aliases in the shell, but they are specific to Git commands. They allow you to create shortcuts for longer commands or to create new commands that are not available by default.


### PR DESCRIPTION
A post on advisories that are real, sit in your dependency tree, describe nothing your code can do, and cost a release anyway. It is dated **2026-09-15**, so `posts/index.ts` keeps it out of production builds until then. It renders in dev.

## The post

Structured as the path one advisory takes: where the score comes from, what the scanner does with it, what lands on the maintainer, what you cannot do about it, what ships, and who pays.

Worked examples are real call sites from Nx, each with the version its fix shipped in:

| Example | Advisory | Why it is noise |
| ------- | -------- | --------------- |
| EJS in a code generator | CVE-2023-29827, 9.8 Critical | Needs attacker control of the options object; that object is a source literal. Bumped anyway, in Nx 22.7.0. |
| minimatch in a glob evaluator | CVE-2022-3517, 7.5 High | Fires exactly as written up, but you supply the payload to your own laptop. |
| Socket alerts on `nx` | "Shell access", "Install scripts" | Accurate, and describing what a task runner is for. No version to bump to, ever. |

A callout near the top states plainly that none of it says Nx is unsafe or that the Nx team mishandles security.

## The components it needed

The blog had no primitive for a source-carrying quote, an editorial aside, or a bibliography, so this adds three.

- **`Callout`** for scope notes and disclaimers, styled unlike `blockquote` so a disclaimer does not read as something a source said.
- **`Quote`** renders `figure`/`blockquote`/`figcaption`, so a quotation carries its source instead of leaving a bare superscript dangling off the sentence that introduced it.
- **`Citations`** replaces hand-written citation numbers. `Cite` no longer takes an `n` prop; numbers come from the order sources are first cited, keyed by href.

Two details worth a reviewer's eye:

**Registration happens during render, not in an effect.** The blog is server-rendered and `reading-time.ts` calls `renderToString` directly, so an effect-based registry would number nothing. That is safe only because `register` is keyed by href and idempotent, so a re-render or StrictMode double-render returns the number already assigned rather than appending.

**Keying by href means a source cited twice keeps one number and one entry.** The cooldown post had three sources cited twice under separate numbers, so its source list drops from 23 to 20 and some reader-visible numbers shift.

## Also in here

The in-content table of contents is gone. The sidebar already builds one from the rendered headings, and because it collects every `h2`/`h3`/`h4` without filtering, "Table of Contents" was showing up as an entry inside the list it duplicated. `remark-toc` is dropped and the heading removed from the four posts that had one.

The top "Return to previous page" link is removed from the post page. The bottom one stays.

## Checks

`nx run blog-posts:lint` and `nx run craigory-dev:build` are green. Citation numbering verified contiguous in the built HTML for both affected posts.

`remark-toc` is still listed in `package.json` and is now unused. I left it rather than trigger a pnpm re-resolve inside this PR.
